### PR TITLE
Add automatic parent branch detection

### DIFF
--- a/branch-diff/src/main.rs
+++ b/branch-diff/src/main.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use gix::object::tree::diff::{Change, ChangeDetached};
 use gix::prelude::*;
+use gix::Repository;
+use gix_hash::ObjectId;
 
 /// Show file changes in a branch relative to a base branch.
 #[derive(Parser, Debug)]
@@ -11,24 +13,41 @@ struct Args {
     #[arg(default_value = ".")]
     repo: std::path::PathBuf,
 
-    /// Name of the branch to compare
-    branch: String,
+    /// Name of the branch to compare. If omitted, the current branch is used.
+    branch: Option<String>,
 
-    /// Name of the base branch
-    #[arg(default_value = "master")]
-    base: String,
+    /// Name of the base branch. If omitted, it will be detected automatically.
+    base: Option<String>,
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
     let repo = gix::discover(&args.repo).context("open repository")?;
 
-    let lhs_id = repo
-        .rev_parse_single(format!("refs/heads/{}", args.base))
-        .context("resolve base branch")?;
+    let branch = match args.branch {
+        Some(b) => b,
+        None => repo
+            .head_name()?
+            .context("current branch is detached")?
+            .to_string()
+            .trim_start_matches("refs/heads/")
+            .to_string(),
+    };
+
     let rhs_id = repo
-        .rev_parse_single(format!("refs/heads/{}", args.branch))
+        .rev_parse_single(format!("refs/heads/{}", branch))
         .context("resolve branch")?;
+
+    let base = match args.base {
+        Some(b) => Some(b),
+        None => detect_base_branch(&repo, &branch, rhs_id.detach())?,
+    };
+
+    let base = base.unwrap_or_else(|| "master".to_string());
+
+    let lhs_id = repo
+        .rev_parse_single(format!("refs/heads/{}", base))
+        .context("resolve base branch")?;
 
     let lhs_commit = repo.find_commit(lhs_id)?;
     let rhs_commit = repo.find_commit(rhs_id)?;
@@ -61,4 +80,28 @@ fn main() -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Try to detect the branch from which `branch` diverged.
+fn detect_base_branch(repo: &Repository, branch: &str, head_id: gix_hash::ObjectId) -> Result<Option<String>> {
+    let mut refs = repo.references()?.local_branches()?.peeled()?;
+    let mut best: Option<(String, i64)> = None;
+    for reference in refs {
+        let mut reference = reference?;
+        let name = reference.name().to_string();
+        if name.trim_start_matches("refs/heads/") == branch {
+            continue;
+        }
+        let target = reference.peel_to_id_in_place()?.detach();
+        if let Ok(base) = repo.merge_base(head_id, target) {
+            if base == target {
+                let commit = repo.find_commit(target)?;
+                let time = commit.time()?.seconds;
+                if best.as_ref().map_or(true, |(_, t)| time > *t) {
+                    best = Some((name, time));
+                }
+            }
+        }
+    }
+    Ok(best.map(|(name, _)| name.trim_start_matches("refs/heads/").to_string()))
 }


### PR DESCRIPTION
## Summary
- improve `branch-diff` to detect current branch and its base branch automatically
- add helper for scanning local branches for the nearest ancestor

## Testing
- `cargo check -p branch-diff --locked --offline` *(fails: could not fetch crates)*
- `cargo run -p branch-diff --offline -- --help` *(fails: could not fetch crates)*


------
https://chatgpt.com/codex/tasks/task_e_683e09f3844483209a0b3261db6405fe

## Summary by Sourcery

Implement automatic detection of both the current branch and its base branch in branch-diff by making their CLI arguments optional and adding a helper to find the nearest ancestor branch

New Features:
- Allow omitting the branch argument to use the current HEAD branch automatically
- Allow omitting the base branch argument and detect its nearest ancestor automatically

Enhancements:
- Introduce a detect_base_branch helper to scan local branches and pick the most recent common ancestor
- Fallback to 'master' if automatic base branch detection yields no result