### PR TITLE
Add branch-info example and history test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "branch-info"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "gix",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,6 +287,7 @@ members = [
     "gix-traverse/tests",
     "gix-shallow",
     "branch-diff",
+    "branch-info",
 ]
 
 [workspace.dependencies]

--- a/branch-info/Cargo.toml
+++ b/branch-info/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "branch-info"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+gix = { path = "../gix", default-features = false, features = ["revision"] }
+
+[lints]
+workspace = true

--- a/branch-info/src/main.rs
+++ b/branch-info/src/main.rs
@@ -1,0 +1,55 @@
+use clap::Parser;
+use gix::{bstr::ByteSlice, remote};
+use std::process::Command;
+
+/// Display information about the current branch and its upstream.
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// Path to the repository
+    #[arg(long, default_value = ".")]
+    repo: std::path::PathBuf,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    run(Args::parse())
+}
+
+fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let repo = gix::discover(&args.repo)?;
+    if let Some(head) = repo.head_name()? {
+        println!(
+            "Current branch: {}",
+            head.shorten().to_str_lossy()
+        );
+        match repo.branch_remote_tracking_ref_name(head.as_ref(), remote::Direction::Fetch) {
+            Some(Ok(name)) => {
+                println!("Upstream branch: {}", name.shorten().to_str_lossy());
+
+                let upstream_commit = repo
+                    .find_reference(name.as_ref())?
+                    .peel_to_commit()?;
+                let head_commit = repo.head_commit()?;
+                let base_id = repo.merge_base(head_commit.id, upstream_commit.id)?.id;
+
+                println!(
+                    "Commits since branching point starting from {}..HEAD:",
+                    base_id
+                );
+                let output = Command::new("git")
+                    .current_dir(repo.workdir().unwrap_or_else(|| repo.git_dir()))
+                    .arg("rev-list")
+                    .arg(format!("{}..HEAD", base_id))
+                    .output()?;
+                if output.status.success() {
+                    print!("{}", String::from_utf8_lossy(&output.stdout));
+                }
+            }
+            Some(Err(err)) => println!("Failed to get upstream: {err}"),
+            None => println!("No upstream configured"),
+        }
+    } else {
+        println!("HEAD is detached");
+    }
+    Ok(())
+}

--- a/branch-info/tests/journey/branch-info.sh
+++ b/branch-info/tests/journey/branch-info.sh
@@ -1,0 +1,21 @@
+# Must be sourced into the main journey test
+
+snapshot="$root/../branch-info/tests/snapshots/branch-info"
+
+(
+  title "branch-info"
+  (when "running in a basic repo"
+    (sandbox
+      gix/tests/fixtures/make_basic_repo.sh >/dev/null
+      git remote add origin bare.git
+      git push origin main:main >/dev/null
+      git branch --set-upstream-to=origin/main
+      echo hi >> this
+      git commit -am c3 >/dev/null
+      it "prints current and upstream branch" && {
+        WITH_SNAPSHOT="$snapshot/basic" \
+        expect_run_sh $SUCCESSFULLY "cargo run -p branch-info -- --repo ."
+      }
+    )
+  )
+)

--- a/branch-info/tests/snapshots/branch-info/basic
+++ b/branch-info/tests/snapshots/branch-info/basic
@@ -1,0 +1,4 @@
+Current branch: main
+Upstream branch: origin/main
+Commits since branching point starting from 507fc876af57e560f32da96a2642042350f90722..HEAD:
+19b10ef3cab1532d899f0e35573a341f6f503824

--- a/tests/journey.sh
+++ b/tests/journey.sh
@@ -38,3 +38,4 @@ set-static-git-environment
 
 source "$root/journey/ein.sh"
 source "$root/journey/gix.sh"
+source "$root/../branch-info/tests/journey/branch-info.sh"


### PR DESCRIPTION
## Summary
- add `branch-info` crate showing branch/upstream info with commit history
- add test under crate folder and include snapshot
- wire crate test into journey script
- fix commit range logic to use merge-base

## Testing
- `cargo fmt` *(fails: `cargo-fmt` not installed)*
- `cargo check` *(fails: `failed to calculate checksum`)*
- `cargo test` *(fails: `failed to calculate checksum`)*


------
https://chatgpt.com/codex/tasks/task_e_68496a53fb988320b28bf48b5580d924

## Summary by Sourcery

Add a new `branch-info` tool to report branch and upstream details with commit history, integrate its tests into the journey CI, and correct commit range computation using merge-base.

New Features:
- Introduce a new `branch-info` CLI crate that displays the current branch, its upstream, and commits since the branching point.

Bug Fixes:
- Fix commit range logic to use the repository merge-base when calculating the branching point.

Build:
- Add `branch-info` to the workspace members and configure its Cargo.toml dependencies.

Tests:
- Add a snapshot-based integration test for `branch-info` and wire it into the journey script.