### PR TITLE
Add commit-frequency analyzer command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,8 +1382,8 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 name = "git-productivity-analyzer"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "gitoxide-core",
  "gix",

--- a/git-productivity-analyzer/Cargo.toml
+++ b/git-productivity-analyzer/Cargo.toml
@@ -10,12 +10,12 @@ clap = { version = "4.5.3", features = ["derive"] }
 miette = { version = "7.6.0", features = ["fancy"] }
 thiserror = "2.0.0"
 tokio = { version = "1.44.2", features = ["rt-multi-thread", "macros"] }
-anyhow = "1.0"
 # Path relative to workspace root
 gitoxide-core = { path = "../gitoxide-core", features = ["estimate-hours"] }
 gix = { path = "../gix", default-features = false, features = ["progress-tree"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -14,9 +14,17 @@ It relies on `gitoxide-core` for heavy lifting and focuses on summarizing how mu
   - `--show-pii` - show personally identifiable information
   - `--omit-unify-identities` - don't deduplicate identities
   - `--threads <n>` - number of threads to use
+- `commit-frequency` — count commits per day and week and report active days per author.
+  - `--working-dir` - path to the repository
+  - `--rev-spec` - revision to analyze
+  - `--author <pattern>` - filter commits by author
 
 All commands accept the global options `--since <date>`, `--until <date>` and `--json` to limit the date range and control the output format.
 
 ## Time Estimation Algorithm
 
 The implementation is based on `gitoxide-core::hours::estimate_hours()` which groups commits by author and time. Commits spaced less than two hours apart are considered part of the same working session. Each session starts with an initial two hour bonus to cover context switching. Optionally the diff of each commit can be examined to track files and lines changed. Identities are unified via `.mailmap` and GitHub bots can be ignored.
+
+## Commit Frequency & Developer Engagement
+
+Commit frequency helps gauge how busy contributors are and how engaged they remain over time. Regular commits across many days indicate an active developer whereas sparse contributions may show less involvement. Weekly totals can highlight periods of intense activity or lulls.

--- a/git-productivity-analyzer/src/cmd/commit_frequency/args.rs
+++ b/git-productivity-analyzer/src/cmd/commit_frequency/args.rs
@@ -1,0 +1,22 @@
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    #[arg(
+        long = "working-dir",
+        default_value = ".",
+        help = "The directory containing a '.git/' folder."
+    )]
+    pub working_dir: PathBuf,
+
+    #[arg(
+        long = "rev-spec",
+        default_value = "HEAD",
+        help = "The revision to start walking from."
+    )]
+    pub rev_spec: String,
+
+    #[arg(long, help = "Only count commits whose author matches this pattern.")]
+    pub author: Option<String>,
+}

--- a/git-productivity-analyzer/src/cmd/commit_frequency/mod.rs
+++ b/git-productivity-analyzer/src/cmd/commit_frequency/mod.rs
@@ -1,0 +1,5 @@
+mod args;
+mod run;
+
+pub use args::Args;
+pub use run::run;

--- a/git-productivity-analyzer/src/cmd/commit_frequency/run.rs
+++ b/git-productivity-analyzer/src/cmd/commit_frequency/run.rs
@@ -6,7 +6,7 @@ use tokio::task;
 
 pub async fn run(args: Args, globals: &Globals) -> Result<()> {
     let globals = globals.clone();
-    task::spawn_blocking(move || crate::sdk::hours::analyze(args, &globals))
+    task::spawn_blocking(move || crate::sdk::commit_frequency::analyze(args, &globals))
         .await
         .into_diagnostic()??;
     Ok(())

--- a/git-productivity-analyzer/src/cmd/commit_frequency/run.rs
+++ b/git-productivity-analyzer/src/cmd/commit_frequency/run.rs
@@ -1,13 +1,10 @@
 use super::args::Args;
 use crate::error::Result;
 use crate::Globals;
-use miette::IntoDiagnostic;
-use tokio::task;
 
 pub async fn run(args: Args, globals: &Globals) -> Result<()> {
-    let globals = globals.clone();
-    task::spawn_blocking(move || crate::sdk::commit_frequency::analyze(args, &globals))
-        .await
-        .into_diagnostic()??;
+    let g = globals.clone();
+    let totals = crate::util::spawn_blocking(move || crate::sdk::commit_frequency::analyze(args, &g)).await?;
+    crate::sdk::commit_frequency::print_totals(globals.json, &totals);
     Ok(())
 }

--- a/git-productivity-analyzer/src/cmd/hours/args.rs
+++ b/git-productivity-analyzer/src/cmd/hours/args.rs
@@ -3,35 +3,59 @@ use std::path::PathBuf;
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
-    /// The directory containing a '.git/' folder.
-    #[arg(long = "working-dir", default_value = ".")]
+    #[arg(
+        long = "working-dir",
+        default_value = ".",
+        help = "The directory containing a '.git/' folder."
+    )]
     pub working_dir: PathBuf,
 
-    /// The name of the revision as spec at which to start iterating the commit graph.
-    #[arg(long = "rev-spec", default_value = "HEAD")]
+    #[arg(
+        long = "rev-spec",
+        default_value = "HEAD",
+        help = "The name of the revision as spec at which to start iterating the commit graph."
+    )]
     pub rev_spec: String,
 
-    /// Ignore github bots which match the `[bot]` search string.
-    #[arg(long = "no-bots", short = 'b')]
+    #[arg(
+        long = "no-bots",
+        short = 'b',
+        help = "Ignore github bots which match the `[bot]` search string."
+    )]
     pub no_bots: bool,
 
-    /// Collect additional information about file modifications, additions and deletions.
-    #[arg(long = "file-stats", short = 'f')]
+    #[arg(
+        long = "file-stats",
+        short = 'f',
+        help = "Collect additional information about file modifications, additions and deletions."
+    )]
     pub file_stats: bool,
 
-    /// Collect additional information about lines added and deleted.
-    #[arg(long = "line-stats", short = 'l')]
+    #[arg(
+        long = "line-stats",
+        short = 'l',
+        help = "Collect additional information about lines added and deleted."
+    )]
     pub line_stats: bool,
 
-    /// Show personally identifiable information before the summary. Includes names and email addresses.
-    #[arg(long = "show-pii", short = 'p')]
+    #[arg(
+        long = "show-pii",
+        short = 'p',
+        help = "Show personally identifiable information before the summary. Includes names and email addresses."
+    )]
     pub show_pii: bool,
 
-    /// Omit unifying identities by name and email which can lead to the same author appearing multiple times.
-    #[arg(long = "omit-unify-identities", short = 'i')]
+    #[arg(
+        long = "omit-unify-identities",
+        short = 'i',
+        help = "Omit unifying identities by name and email which can lead to the same author appearing multiple times."
+    )]
     pub omit_unify_identities: bool,
 
-    /// The amount of threads to use. If unset, use all cores, if 0 use all physical cores.
-    #[arg(long, short = 't')]
+    #[arg(
+        long,
+        short = 't',
+        help = "The amount of threads to use. If unset, use all cores, if 0 use all physical cores."
+    )]
     pub threads: Option<usize>,
 }

--- a/git-productivity-analyzer/src/cmd/hours/run.rs
+++ b/git-productivity-analyzer/src/cmd/hours/run.rs
@@ -1,13 +1,9 @@
 use super::args::Args;
 use crate::error::Result;
 use crate::Globals;
-use miette::IntoDiagnostic;
-use tokio::task;
 
 pub async fn run(args: Args, globals: &Globals) -> Result<()> {
-    let globals = globals.clone();
-    task::spawn_blocking(move || crate::sdk::hours::analyze(args, &globals))
-        .await
-        .into_diagnostic()??;
+    let g = globals.clone();
+    crate::util::spawn_blocking(move || crate::sdk::hours::analyze(args, &g)).await?;
     Ok(())
 }

--- a/git-productivity-analyzer/src/cmd/mod.rs
+++ b/git-productivity-analyzer/src/cmd/mod.rs
@@ -1,9 +1,12 @@
+pub mod commit_frequency;
 pub mod hours;
 
 use clap::Subcommand;
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    /// Estimate time spent on repository work
+    #[command(about = "Estimate time spent on repository work")]
     Hours(hours::Args),
+    #[command(about = "Count commits per day and week")]
+    CommitFrequency(commit_frequency::Args),
 }

--- a/git-productivity-analyzer/src/error.rs
+++ b/git-productivity-analyzer/src/error.rs
@@ -1,8 +1,2 @@
-use miette::Diagnostic;
-use thiserror::Error;
-
-#[derive(Debug, Error, Diagnostic)]
-#[error(transparent)]
-pub struct Error(#[from] anyhow::Error);
-
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Error = miette::Report;
+pub type Result<T> = miette::Result<T>;

--- a/git-productivity-analyzer/src/error.rs
+++ b/git-productivity-analyzer/src/error.rs
@@ -1,2 +1,1 @@
-pub type Error = miette::Report;
 pub type Result<T> = miette::Result<T>;

--- a/git-productivity-analyzer/src/main.rs
+++ b/git-productivity-analyzer/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 mod cmd;
 mod error;
 mod sdk;
+mod util;
 
 use crate::error::Result;
 

--- a/git-productivity-analyzer/src/main.rs
+++ b/git-productivity-analyzer/src/main.rs
@@ -2,10 +2,12 @@ use clap::Parser;
 
 mod cmd;
 mod error;
+mod sdk;
 
 use crate::error::Result;
 
 /// Shared options available to all subcommands.
+#[derive(Clone)]
 pub struct Globals {
     pub since: Option<String>,
     pub until: Option<String>,
@@ -15,14 +17,11 @@ pub struct Globals {
 #[derive(Debug, Parser)]
 #[command(name = "git-productivity-analyzer")]
 struct Cli {
-    /// Start date for analysis (inclusive)
-    #[arg(long)]
+    #[arg(long, help = "Start date for analysis (inclusive)")]
     since: Option<String>,
-    /// End date for analysis (inclusive)
-    #[arg(long)]
+    #[arg(long, help = "End date for analysis (inclusive)")]
     until: Option<String>,
-    /// Produce JSON output
-    #[arg(long)]
+    #[arg(long, help = "Produce JSON output")]
     json: bool,
     #[command(subcommand)]
     command: cmd::Command,
@@ -39,5 +38,6 @@ async fn main() -> Result<()> {
     let globals = Globals { since, until, json };
     match command {
         cmd::Command::Hours(args) => cmd::hours::run(args, &globals).await,
+        cmd::Command::CommitFrequency(args) => cmd::commit_frequency::run(args, &globals).await,
     }
 }

--- a/git-productivity-analyzer/src/sdk/commit_frequency/analyzer.rs
+++ b/git-productivity-analyzer/src/sdk/commit_frequency/analyzer.rs
@@ -1,25 +1,29 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::{Globals, cmd::commit_frequency::Args, error::Result};
+use crate::{cmd::commit_frequency::Args, error::Result, Globals};
+use chrono::{naive::IsoWeek, NaiveDate};
 use gix::bstr::ByteSlice;
 use gix::prelude::*;
 use miette::IntoDiagnostic;
 
 use super::processor::process_commit;
 
-#[derive(serde::Serialize)]
-struct Totals {
-    commits_per_day: BTreeMap<String, u32>,
-    commits_per_week: BTreeMap<String, u32>,
-    active_days_per_author: BTreeMap<String, u32>,
+pub struct Totals {
+    pub commits_per_day: BTreeMap<NaiveDate, u32>,
+    pub commits_per_week: BTreeMap<IsoWeek, u32>,
+    pub active_days_per_author: BTreeMap<String, BTreeSet<NaiveDate>>,
 }
 
-pub fn analyze(args: Args, globals: &Globals) -> Result<()> {
+pub fn analyze(args: Args, globals: &Globals) -> Result<Totals> {
     let repo = gix::discover(&args.working_dir).into_diagnostic()?;
     let start = resolve_start_commit(&repo, &args.rev_spec, globals)?;
     let since = resolve_since_commit(&repo, &globals.since)?;
 
-    let (mut daily, mut weekly, mut days_by_author) = (BTreeMap::new(), BTreeMap::new(), BTreeMap::new());
+    let (mut daily, mut weekly, mut days_by_author) = (
+        BTreeMap::<NaiveDate, u32>::new(),
+        BTreeMap::<IsoWeek, u32>::new(),
+        BTreeMap::<String, BTreeSet<NaiveDate>>::new(),
+    );
     walk_commits(
         &repo,
         start,
@@ -30,8 +34,11 @@ pub fn analyze(args: Args, globals: &Globals) -> Result<()> {
         &mut days_by_author,
     )?;
 
-    output_results(globals.json, daily, weekly, days_by_author);
-    Ok(())
+    Ok(Totals {
+        commits_per_day: daily,
+        commits_per_week: weekly,
+        active_days_per_author: days_by_author,
+    })
 }
 
 fn resolve_start_commit(repo: &gix::Repository, rev_spec: &str, globals: &Globals) -> Result<gix::ObjectId> {
@@ -58,14 +65,15 @@ fn walk_commits(
     start: gix::ObjectId,
     since: Option<&gix::ObjectId>,
     author_filter: &Option<String>,
-    days: &mut BTreeMap<String, u32>,
-    weeks: &mut BTreeMap<String, u32>,
-    by_author: &mut BTreeMap<String, BTreeSet<String>>,
+    days: &mut BTreeMap<NaiveDate, u32>,
+    weeks: &mut BTreeMap<IsoWeek, u32>,
+    by_author: &mut BTreeMap<String, BTreeSet<NaiveDate>>,
 ) -> Result<()> {
-    let mut iter = start.ancestors(&repo.objects);
-    while let Some(item) = iter.next() {
+    let iter = start.ancestors(&repo.objects);
+    let mut buf = Vec::new();
+    for item in iter {
         let info = item.into_diagnostic()?;
-        let commit = iter.commit_iter();
+        let commit = repo.objects.find_commit_iter(&info.id, &mut buf).into_diagnostic()?;
         process_commit(commit, author_filter, days, weeks, by_author)?;
         if let Some(id) = since {
             if &info.id == id {
@@ -76,28 +84,44 @@ fn walk_commits(
     Ok(())
 }
 
-fn output_results(
-    json: bool,
+pub fn print_totals(json: bool, totals: &Totals) {
+    if json {
+        let ser = SerializableTotals::from(totals);
+        let _ = serde_json::to_writer(std::io::stdout(), &ser).map(|_| println!());
+    } else {
+        for (day, count) in &totals.commits_per_day {
+            println!("{}: {count}", day);
+        }
+        for (week, count) in &totals.commits_per_week {
+            println!("week {}-{:02}: {count}", week.year(), week.week());
+        }
+        for (author, days) in &totals.active_days_per_author {
+            println!("{author} active days: {}", days.len());
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct SerializableTotals {
     commits_per_day: BTreeMap<String, u32>,
     commits_per_week: BTreeMap<String, u32>,
-    days_by_author: BTreeMap<String, BTreeSet<String>>,
-) {
-    if json {
-        let totals = Totals {
-            commits_per_day,
-            commits_per_week,
-            active_days_per_author: days_by_author.into_iter().map(|(k, v)| (k, v.len() as u32)).collect(),
-        };
-        let _ = serde_json::to_writer(std::io::stdout(), &totals).map(|_| println!());
-    } else {
-        for (day, count) in &commits_per_day {
-            println!("{day}: {count}");
-        }
-        for (week, count) in &commits_per_week {
-            println!("week {week}: {count}");
-        }
-        for (author, days) in &days_by_author {
-            println!("{author} active days: {}", days.len());
+    active_days_per_author: BTreeMap<String, u32>,
+}
+
+impl From<&Totals> for SerializableTotals {
+    fn from(t: &Totals) -> Self {
+        Self {
+            commits_per_day: t.commits_per_day.iter().map(|(d, c)| (d.to_string(), *c)).collect(),
+            commits_per_week: t
+                .commits_per_week
+                .iter()
+                .map(|(w, c)| (format!("{}-{:02}", w.year(), w.week()), *c))
+                .collect(),
+            active_days_per_author: t
+                .active_days_per_author
+                .iter()
+                .map(|(a, set)| (a.clone(), set.len() as u32))
+                .collect(),
         }
     }
 }

--- a/git-productivity-analyzer/src/sdk/commit_frequency/analyzer.rs
+++ b/git-productivity-analyzer/src/sdk/commit_frequency/analyzer.rs
@@ -1,0 +1,110 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{cmd::commit_frequency::Args, error::Result, Globals};
+use gix::bstr::ByteSlice;
+use gix::prelude::*;
+use miette::IntoDiagnostic;
+
+use super::processor::process_commit;
+
+#[derive(serde::Serialize)]
+struct Totals {
+    commits_per_day: BTreeMap<String, u32>,
+    commits_per_week: BTreeMap<String, u32>,
+    active_days_per_author: BTreeMap<String, u32>,
+}
+
+pub fn analyze(args: Args, globals: &Globals) -> Result<()> {
+    let repo = gix::discover(&args.working_dir).into_diagnostic()?;
+    let start = resolve_start_commit(&repo, &args.rev_spec, globals)?;
+    let since = resolve_since_commit(&repo, &globals.since)?;
+
+    let (mut daily, mut weekly, mut days_by_author) = (BTreeMap::new(), BTreeMap::new(), BTreeMap::new());
+    walk_commits(
+        &repo,
+        start,
+        since.as_ref(),
+        &args.author,
+        &mut daily,
+        &mut weekly,
+        &mut days_by_author,
+    )?;
+
+    output_results(globals.json, daily, weekly, days_by_author);
+    Ok(())
+}
+
+fn resolve_start_commit<'repo>(
+    repo: &'repo gix::Repository,
+    rev_spec: &str,
+    globals: &Globals,
+) -> Result<gix::ObjectId> {
+    let spec = globals.until.as_deref().unwrap_or(rev_spec);
+    Ok(repo
+        .rev_parse_single(spec.as_bytes().as_bstr())
+        .into_diagnostic()?
+        .detach())
+}
+
+fn resolve_since_commit<'repo>(repo: &'repo gix::Repository, since: &Option<String>) -> Result<Option<gix::ObjectId>> {
+    match since {
+        Some(spec) => Ok(Some(
+            repo.rev_parse_single(spec.as_bytes().as_bstr())
+                .into_diagnostic()?
+                .detach(),
+        )),
+        None => Ok(None),
+    }
+}
+
+fn walk_commits<'repo>(
+    repo: &'repo gix::Repository,
+    start: gix::ObjectId,
+    since: Option<&gix::ObjectId>,
+    author_filter: &Option<String>,
+    days: &mut BTreeMap<String, u32>,
+    weeks: &mut BTreeMap<String, u32>,
+    by_author: &mut BTreeMap<String, BTreeSet<String>>,
+) -> Result<()> {
+    let mut iter = start.ancestors(&repo.objects);
+    while let Some(item) = iter.next() {
+        let info = item.into_diagnostic()?;
+        let commit = iter.commit_iter();
+        process_commit(commit, author_filter, days, weeks, by_author)?;
+        if let Some(id) = since {
+            if &info.id == id {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn output_results(
+    json: bool,
+    commits_per_day: BTreeMap<String, u32>,
+    commits_per_week: BTreeMap<String, u32>,
+    days_by_author: BTreeMap<String, BTreeSet<String>>,
+) {
+    if json {
+        let totals = Totals {
+            commits_per_day,
+            commits_per_week,
+            active_days_per_author: days_by_author.into_iter().map(|(k, v)| (k, v.len() as u32)).collect(),
+        };
+        let _ = serde_json::to_writer(std::io::stdout(), &totals).and_then(|_| {
+            println!();
+            Ok(())
+        });
+    } else {
+        for (day, count) in &commits_per_day {
+            println!("{day}: {count}");
+        }
+        for (week, count) in &commits_per_week {
+            println!("week {week}: {count}");
+        }
+        for (author, days) in &days_by_author {
+            println!("{author} active days: {}", days.len());
+        }
+    }
+}

--- a/git-productivity-analyzer/src/sdk/commit_frequency/mod.rs
+++ b/git-productivity-analyzer/src/sdk/commit_frequency/mod.rs
@@ -1,4 +1,4 @@
 mod analyzer;
 mod processor;
 
-pub use analyzer::analyze;
+pub use analyzer::{analyze, print_totals};

--- a/git-productivity-analyzer/src/sdk/commit_frequency/mod.rs
+++ b/git-productivity-analyzer/src/sdk/commit_frequency/mod.rs
@@ -1,0 +1,4 @@
+mod analyzer;
+mod processor;
+
+pub use analyzer::analyze;

--- a/git-productivity-analyzer/src/sdk/commit_frequency/processor.rs
+++ b/git-productivity-analyzer/src/sdk/commit_frequency/processor.rs
@@ -1,0 +1,33 @@
+use chrono::Datelike;
+use gix::bstr::ByteSlice;
+use gix::prelude::*;
+use miette::IntoDiagnostic;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::error::Result;
+
+pub(crate) fn process_commit(
+    mut commit: gix::objs::CommitRefIter<'_>,
+    author_filter: &Option<String>,
+    days: &mut BTreeMap<String, u32>,
+    weeks: &mut BTreeMap<String, u32>,
+    by_author: &mut BTreeMap<String, BTreeSet<String>>,
+) -> Result<()> {
+    let author = commit.author().into_diagnostic()?;
+    let author_string = format!("{} <{}>", author.name, author.email);
+    if let Some(pattern) = author_filter {
+        let pat = pattern.as_str();
+        if !author.name.to_str_lossy().contains(pat) && !author.email.to_str_lossy().contains(pat) {
+            return Ok(());
+        }
+    }
+    let ts = author.seconds();
+    let date = chrono::NaiveDateTime::from_timestamp_opt(ts as i64, 0).unwrap().date();
+    let day = date.to_string();
+    *days.entry(day.clone()).or_insert(0) += 1;
+    let iso_week = date.iso_week();
+    let week = format!("{}-{:02}", iso_week.year(), iso_week.week());
+    *weeks.entry(week).or_insert(0) += 1;
+    by_author.entry(author_string).or_default().insert(day);
+    Ok(())
+}

--- a/git-productivity-analyzer/src/sdk/commit_frequency/processor.rs
+++ b/git-productivity-analyzer/src/sdk/commit_frequency/processor.rs
@@ -1,4 +1,4 @@
-use chrono::Datelike;
+use chrono::{naive::IsoWeek, Datelike, NaiveDate};
 use gix::bstr::ByteSlice;
 use miette::IntoDiagnostic;
 use std::collections::{BTreeMap, BTreeSet};
@@ -8,9 +8,9 @@ use crate::error::Result;
 pub(crate) fn process_commit(
     commit: gix::objs::CommitRefIter<'_>,
     author_filter: &Option<String>,
-    days: &mut BTreeMap<String, u32>,
-    weeks: &mut BTreeMap<String, u32>,
-    by_author: &mut BTreeMap<String, BTreeSet<String>>,
+    days: &mut BTreeMap<NaiveDate, u32>,
+    weeks: &mut BTreeMap<IsoWeek, u32>,
+    by_author: &mut BTreeMap<String, BTreeSet<NaiveDate>>,
 ) -> Result<()> {
     let author = commit.author().into_diagnostic()?;
     let author_string = format!("{} <{}>", author.name, author.email);
@@ -24,11 +24,9 @@ pub(crate) fn process_commit(
     let date = chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
         .ok_or_else(|| miette::miette!("invalid timestamp {ts}"))?
         .date_naive();
-    let day = date.to_string();
-    *days.entry(day.clone()).or_insert(0) += 1;
-    let iso_week = date.iso_week();
-    let week = format!("{}-{:02}", iso_week.year(), iso_week.week());
+    *days.entry(date).or_insert(0) += 1;
+    let week = date.iso_week();
     *weeks.entry(week).or_insert(0) += 1;
-    by_author.entry(author_string).or_default().insert(day);
+    by_author.entry(author_string).or_default().insert(date);
     Ok(())
 }

--- a/git-productivity-analyzer/src/sdk/commit_frequency/processor.rs
+++ b/git-productivity-analyzer/src/sdk/commit_frequency/processor.rs
@@ -1,13 +1,12 @@
 use chrono::Datelike;
 use gix::bstr::ByteSlice;
-use gix::prelude::*;
 use miette::IntoDiagnostic;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::error::Result;
 
 pub(crate) fn process_commit(
-    mut commit: gix::objs::CommitRefIter<'_>,
+    commit: gix::objs::CommitRefIter<'_>,
     author_filter: &Option<String>,
     days: &mut BTreeMap<String, u32>,
     weeks: &mut BTreeMap<String, u32>,
@@ -22,7 +21,9 @@ pub(crate) fn process_commit(
         }
     }
     let ts = author.seconds();
-    let date = chrono::NaiveDateTime::from_timestamp_opt(ts as i64, 0).unwrap().date();
+    let date = chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
+        .ok_or_else(|| miette::miette!("invalid timestamp {ts}"))?
+        .date_naive();
     let day = date.to_string();
     *days.entry(day.clone()).or_insert(0) += 1;
     let iso_week = date.iso_week();

--- a/git-productivity-analyzer/src/sdk/hours/analyzer.rs
+++ b/git-productivity-analyzer/src/sdk/hours/analyzer.rs
@@ -1,0 +1,49 @@
+use crate::cmd::hours::Args;
+use crate::error::Result;
+use gitoxide_core::hours::{estimate, Context};
+use gix::bstr::ByteSlice;
+use miette::IntoDiagnostic;
+use serde::Serialize;
+use std::io::Write;
+
+#[derive(Serialize, Default)]
+pub(crate) struct Summary {
+    pub(crate) total_hours: f32,
+    pub(crate) total_8h_days: f32,
+    pub(crate) total_commits: u32,
+    pub(crate) total_authors: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) total_files: Option<[u32; 4]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) total_lines: Option<[u32; 3]>,
+}
+
+pub fn analyze(args: Args, globals: &crate::Globals) -> Result<()> {
+    let mut out_buf = Vec::new();
+    let spec = globals.until.as_deref().unwrap_or(&args.rev_spec);
+    estimate(
+        &args.working_dir,
+        spec.as_bytes().as_bstr(),
+        &mut gix::progress::Discard,
+        Context {
+            show_pii: args.show_pii,
+            ignore_bots: args.no_bots,
+            file_stats: args.file_stats,
+            line_stats: args.line_stats,
+            omit_unify_identities: args.omit_unify_identities,
+            threads: args.threads,
+            out: &mut out_buf,
+        },
+    )
+    .map_err(|e| miette::Report::msg(e.to_string()))?;
+
+    if globals.json {
+        let out_str = std::str::from_utf8(&out_buf).into_diagnostic()?;
+        let summary = super::parser::parse_summary(out_str);
+        serde_json::to_writer(std::io::stdout(), &summary).into_diagnostic()?;
+        println!();
+    } else {
+        std::io::stdout().write_all(&out_buf).into_diagnostic()?;
+    }
+    Ok(())
+}

--- a/git-productivity-analyzer/src/sdk/hours/mod.rs
+++ b/git-productivity-analyzer/src/sdk/hours/mod.rs
@@ -1,0 +1,4 @@
+mod analyzer;
+mod parser;
+
+pub use analyzer::analyze;

--- a/git-productivity-analyzer/src/sdk/hours/parser.rs
+++ b/git-productivity-analyzer/src/sdk/hours/parser.rs
@@ -1,0 +1,41 @@
+use super::analyzer::Summary;
+
+pub(crate) fn parse_summary(out: &str) -> Summary {
+    let mut summary = Summary::default();
+    for line in out.lines() {
+        parse_line(line, &mut summary);
+    }
+    summary
+}
+
+fn parse_line(line: &str, summary: &mut Summary) {
+    if let Some(v) = line.strip_prefix("total hours: ") {
+        summary.total_hours = v.trim().parse().unwrap_or_default();
+    } else if let Some(v) = line.strip_prefix("total 8h days: ") {
+        summary.total_8h_days = v.trim().parse().unwrap_or_default();
+    } else if let Some(v) = line.strip_prefix("total commits = ") {
+        let num = v.split_whitespace().next().unwrap_or("0");
+        summary.total_commits = num.parse().unwrap_or_default();
+    } else if let Some(v) = line.strip_prefix("total authors: ") {
+        summary.total_authors = v.trim().parse().unwrap_or_default();
+    } else if let Some(v) = line.strip_prefix("total files added/removed/modified/remaining: ") {
+        summary.total_files = parse_numbers::<4>(v);
+    } else if let Some(v) = line.strip_prefix("total lines added/removed/remaining: ") {
+        summary.total_lines = parse_numbers::<3>(v);
+    }
+}
+
+fn parse_numbers<const N: usize>(v: &str) -> Option<[u32; N]> {
+    let parts: Vec<u32> = v
+        .split('/')
+        .filter_map(|p| p.split_whitespace().next())
+        .filter_map(|p| p.parse().ok())
+        .collect();
+    if parts.len() == N {
+        let mut arr = [0u32; N];
+        arr.copy_from_slice(&parts);
+        Some(arr)
+    } else {
+        None
+    }
+}

--- a/git-productivity-analyzer/src/sdk/mod.rs
+++ b/git-productivity-analyzer/src/sdk/mod.rs
@@ -1,0 +1,2 @@
+pub mod commit_frequency;
+pub mod hours;

--- a/git-productivity-analyzer/src/util.rs
+++ b/git-productivity-analyzer/src/util.rs
@@ -1,0 +1,11 @@
+use crate::error::Result;
+use miette::IntoDiagnostic;
+use tokio::task;
+
+pub async fn spawn_blocking<F, T>(func: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    task::spawn_blocking(func).await.into_diagnostic()?
+}

--- a/tests/commit-frequency.sh
+++ b/tests/commit-frequency.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eu -o pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+source "$SCRIPT_DIR/utilities.sh"
+SUCCESSFULLY=0
+
+COMMITTERS=(
+  "Sebastian Thiel"
+  "Eliah Kagan"
+  "Edward Shen"
+)
+
+snapshot="$SCRIPT_DIR/snapshots/commit-frequency"
+
+(title "commit-frequency" && \
+  repo_root="$PWD" && \
+  (
+    sandbox && (
+      git init &&
+      git checkout -b main &&
+      git config commit.gpgsign false &&
+      git config tag.gpgsign false &&
+      touch a && git add a && \
+      GIT_AUTHOR_NAME="${COMMITTERS[0]}" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="${COMMITTERS[0]}" GIT_COMMITTER_EMAIL=a@example.com git commit -m first &&
+      touch b && git add b && \
+      GIT_AUTHOR_NAME="${COMMITTERS[1]}" GIT_AUTHOR_EMAIL=b@example.com \
+      GIT_COMMITTER_NAME="${COMMITTERS[1]}" GIT_COMMITTER_EMAIL=b@example.com git commit -m second &&
+      echo hi >> b && git add b && \
+      GIT_AUTHOR_NAME="${COMMITTERS[2]}" GIT_AUTHOR_EMAIL=c@example.com \
+      GIT_COMMITTER_NAME="${COMMITTERS[2]}" GIT_COMMITTER_EMAIL=c@example.com git commit -m third
+    )
+    export REPO_ROOT="$repo_root"
+    it "prints commit frequency" && {
+      WITH_SNAPSHOT="$snapshot/default" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- commit-frequency --working-dir \"$PWD\" 2>/dev/null)"
+    }
+    idx=0
+    for name in "${COMMITTERS[@]}"; do
+      file="$(echo "$name" | tr ' ' '-')"
+      it "prints commit frequency for $name" && {
+        WITH_SNAPSHOT="$snapshot/$file" \
+        expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- commit-frequency --working-dir \"$PWD\" --author \"$name\" 2>/dev/null)"
+      }
+      idx=$((idx+1))
+    done
+  )
+)

--- a/tests/snapshots/commit-frequency/Edward-Shen
+++ b/tests/snapshots/commit-frequency/Edward-Shen
@@ -1,0 +1,3 @@
+2025-06-24: 1
+week 2025-26: 1
+Edward Shen <c@example.com> active days: 1

--- a/tests/snapshots/commit-frequency/Eliah-Kagan
+++ b/tests/snapshots/commit-frequency/Eliah-Kagan
@@ -1,0 +1,3 @@
+2025-06-24: 1
+week 2025-26: 1
+Eliah Kagan <b@example.com> active days: 1

--- a/tests/snapshots/commit-frequency/Sebastian-Thiel
+++ b/tests/snapshots/commit-frequency/Sebastian-Thiel
@@ -1,0 +1,3 @@
+2025-06-24: 1
+week 2025-26: 1
+Sebastian Thiel <a@example.com> active days: 1

--- a/tests/snapshots/commit-frequency/default
+++ b/tests/snapshots/commit-frequency/default
@@ -1,0 +1,5 @@
+2025-06-24: 3
+week 2025-26: 3
+Edward Shen <c@example.com> active days: 1
+Eliah Kagan <b@example.com> active days: 1
+Sebastian Thiel <a@example.com> active days: 1


### PR DESCRIPTION
## Summary
- add `commit-frequency` subcommand to `git-productivity-analyzer`
- migrate CLI help text to clap attributes
- switch error handling to `miette` and move plumbing to `sdk`
- extend test to cover multiple committers
- refactor sdk modules into dedicated folders with clearer function names

## Testing
- `cargo build --message-format short -p git-productivity-analyzer`
- `cargo check --message-format short -p git-productivity-analyzer`
- `cargo test --message-format short -p git-productivity-analyzer`
- `cargo clippy --message-format short -p git-productivity-analyzer`
- `cargo run -p git-productivity-analyzer -- --help ""`
- `bash tests/commit-frequency.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b0ab14d688320afc9e05f5660adc2

## Summary by Sourcery

Introduce a new `commit-frequency` analyzer command and streamline the codebase by migrating core logic into dedicated SDK modules, improving error handling with miette, enhancing CLI help text, and adding comprehensive tests and documentation.

New Features:
- Add `commit-frequency` subcommand to report commits per day/week and active days per author, with optional author filtering

Enhancements:
- Migrate analysis logic into `sdk` modules and refactor `hours` command to use shared analyzer functions
- Annotate all CLI options with `clap` help attributes
- Switch error handling to use `miette::Report` throughout the project and centralize plumbing in `error.rs`

Build:
- Remove `anyhow` dependency and add `chrono` for date handling

Documentation:
- Update README to document the new `commit-frequency` command and engagement metrics

Tests:
- Add end-to-end shell test for `commit-frequency`, including snapshots for multiple committers