### PR TITLE
Add SDK for branch-client and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "branch-client"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "gix",
+ "miette",
+ "tempfile",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "branch-diff"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,6 +288,7 @@ members = [
     "gix-shallow",
     "branch-diff",
     "branch-info",
+    "branch-client",
     "merge-preview",
     "git-productivity-analyzer",
 ]

--- a/branch-client/Cargo.toml
+++ b/branch-client/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "branch-client"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+clap = { version = "4.5.3", features = ["derive"] }
+miette = { version = "7.6.0", features = ["fancy"] }
+thiserror = "2.0.0"
+gix = { path = "../gix", default-features = false, features = ["revision"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/branch-client/README.md
+++ b/branch-client/README.md
@@ -1,0 +1,13 @@
+# branch-client
+
+Command line utility to manage Git branches using `gix`.
+
+## Features
+
+- List local or remote branches
+- Create new branches from any revision
+- Delete branches
+- Compare two branches and show how many commits they are ahead or behind
+- Cleanup merged branches (local only)
+
+This is an early proof of concept and does not push to remotes yet.

--- a/branch-client/src/cmd/cleanup.rs
+++ b/branch-client/src/cmd/cleanup.rs
@@ -1,0 +1,19 @@
+use crate::sdk::branch::cleanup_merged_branches;
+use clap::Args as ClapArgs;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    #[arg(long, help = "Only show what would be deleted")]
+    pub dry_run: bool,
+}
+
+pub fn run(repo: &gix::Repository, args: Args) -> crate::error::Result<()> {
+    for name in cleanup_merged_branches(repo, args.dry_run)? {
+        if args.dry_run {
+            println!("would delete {name}");
+        } else {
+            println!("deleted {name}");
+        }
+    }
+    Ok(())
+}

--- a/branch-client/src/cmd/compare.rs
+++ b/branch-client/src/cmd/compare.rs
@@ -1,0 +1,14 @@
+use crate::sdk::branch::compare_branches;
+use clap::Args as ClapArgs;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    pub lhs: String,
+    pub rhs: String,
+}
+
+pub fn run(repo: &gix::Repository, args: Args) -> crate::error::Result<()> {
+    let (ahead, behind) = compare_branches(repo, &args.lhs, &args.rhs)?;
+    println!("ahead {ahead}, behind {behind}");
+    Ok(())
+}

--- a/branch-client/src/cmd/create.rs
+++ b/branch-client/src/cmd/create.rs
@@ -1,0 +1,13 @@
+use crate::sdk::branch::create_branch;
+use clap::Args as ClapArgs;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    pub name: String,
+    #[arg(long, default_value = "HEAD", help = "Starting point for the branch")]
+    pub start: String,
+}
+
+pub fn run(repo: &gix::Repository, args: Args) -> crate::error::Result<()> {
+    create_branch(repo, &args.name, &args.start)
+}

--- a/branch-client/src/cmd/delete.rs
+++ b/branch-client/src/cmd/delete.rs
@@ -1,0 +1,11 @@
+use crate::sdk::branch::delete_branch;
+use clap::Args as ClapArgs;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    pub name: String,
+}
+
+pub fn run(repo: &gix::Repository, args: Args) -> crate::error::Result<()> {
+    delete_branch(repo, &args.name)
+}

--- a/branch-client/src/cmd/list.rs
+++ b/branch-client/src/cmd/list.rs
@@ -1,0 +1,15 @@
+use crate::sdk::branch::list_branches;
+use clap::Args as ClapArgs;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    #[arg(long, help = "List remote branches instead of local")]
+    pub remote: bool,
+}
+
+pub fn run(repo: &gix::Repository, args: Args) -> crate::error::Result<()> {
+    for name in list_branches(repo, args.remote)? {
+        println!("{}", name);
+    }
+    Ok(())
+}

--- a/branch-client/src/cmd/mod.rs
+++ b/branch-client/src/cmd/mod.rs
@@ -1,0 +1,21 @@
+pub mod cleanup;
+pub mod compare;
+pub mod create;
+pub mod delete;
+pub mod list;
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    #[command(about = "List branches")]
+    List(list::Args),
+    #[command(about = "Create a new branch")]
+    Create(create::Args),
+    #[command(about = "Delete a branch")]
+    Delete(delete::Args),
+    #[command(about = "Compare branches")]
+    Compare(compare::Args),
+    #[command(about = "Cleanup merged branches")]
+    Cleanup(cleanup::Args),
+}

--- a/branch-client/src/error.rs
+++ b/branch-client/src/error.rs
@@ -1,0 +1,5 @@
+//! Simple type alias used throughout the crate for convenience.
+//!
+//! Using [`miette::Result`] makes all our functions return rich diagnostic
+//! errors without repeating the full type signature.
+pub type Result<T> = miette::Result<T>;

--- a/branch-client/src/main.rs
+++ b/branch-client/src/main.rs
@@ -1,0 +1,29 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+mod cmd;
+mod error;
+pub mod sdk;
+
+use crate::error::Result;
+
+#[derive(Debug, Parser)]
+#[command(name = "branch-client")]
+struct Cli {
+    #[arg(long, default_value = ".", help = "Path to the repository")]
+    repo: PathBuf,
+    #[command(subcommand)]
+    command: cmd::Command,
+}
+
+fn main() -> Result<()> {
+    let args = Cli::parse();
+    let repo = sdk::repo::open_repo(&args.repo)?;
+    match args.command {
+        cmd::Command::List(a) => cmd::list::run(&repo, a),
+        cmd::Command::Create(a) => cmd::create::run(&repo, a),
+        cmd::Command::Delete(a) => cmd::delete::run(&repo, a),
+        cmd::Command::Compare(a) => cmd::compare::run(&repo, a),
+        cmd::Command::Cleanup(a) => cmd::cleanup::run(&repo, a),
+    }
+}

--- a/branch-client/src/sdk/branch.rs
+++ b/branch-client/src/sdk/branch.rs
@@ -1,0 +1,125 @@
+//! Helpers for common branch operations built on top of [`gix`].
+//!
+//! The functions in this module provide minimal wrappers around `gix` APIs so
+//! each CLI command can reuse them. They return [`crate::error::Result`] for a
+//! consistent error type.
+
+use miette::IntoDiagnostic;
+
+use crate::error::Result;
+
+/// Return the list of local or remote branch names.
+pub fn list_branches(repo: &gix::Repository, remote: bool) -> Result<Vec<String>> {
+    // Obtain an iterator over all references in the repository.
+    let references = repo.references().into_diagnostic()?;
+    // Depending on the flag, narrow the iterator to either local or remote
+    // branches. `remote_branches` and `local_branches` filter the reference
+    // namespace for `refs/remotes/*` and `refs/heads/*` respectively.
+    let refs = if remote {
+        references.remote_branches().into_diagnostic()?
+    } else {
+        references.local_branches().into_diagnostic()?
+    };
+    let mut names = Vec::new();
+    // Each item of `refs` yields a result with a `Reference`. Convert the
+    // reference into a printable short name like `main` and collect.
+    for r in refs {
+        let r = r.map_err(|e| miette::Report::msg(e.to_string()))?;
+        names.push(r.name().shorten().to_string());
+    }
+    Ok(names)
+}
+
+/// Create a new branch `name` starting from revision `start`.
+pub fn create_branch(repo: &gix::Repository, name: &str, start: &str) -> Result<()> {
+    // `rev_parse_single` resolves the provided revision string (like "HEAD" or a
+    // commit hash) to an object id.
+    let id = repo.rev_parse_single(start).into_diagnostic()?;
+    // Create `refs/heads/<name>` pointing to that id. `PreviousValue::MustNotExist`
+    // ensures the reference did not already exist.
+    repo.reference(
+        format!("refs/heads/{name}"),
+        id,
+        gix::refs::transaction::PreviousValue::MustNotExist,
+        "branch created",
+    )
+    .into_diagnostic()?;
+    Ok(())
+}
+
+/// Remove the branch `name` from `refs/heads/`.
+pub fn delete_branch(repo: &gix::Repository, name: &str) -> Result<()> {
+    // Look up the reference and delete it in one call.
+    let r = repo.find_reference(&format!("refs/heads/{name}")).into_diagnostic()?;
+    r.delete().into_diagnostic()?;
+    Ok(())
+}
+
+/// Return `(ahead, behind)` commit counts comparing `lhs` and `rhs`.
+pub fn compare_branches(repo: &gix::Repository, lhs: &str, rhs: &str) -> Result<(usize, usize)> {
+    // Resolve both revision strings to object ids.
+    let lhs = repo.rev_parse_single(lhs).into_diagnostic()?;
+    let rhs = repo.rev_parse_single(rhs).into_diagnostic()?;
+
+    // Count commits reachable from `lhs` but not `rhs`.
+    // `rev_walk` starts an iterator over commits and `with_boundary` stops once
+    // the boundary revision is encountered.
+    let ahead = repo
+        .rev_walk([lhs])
+        .with_boundary([rhs])
+        .all()
+        .into_diagnostic()?
+        .filter_map(std::result::Result::ok)
+        .count();
+
+    // Count commits reachable from `rhs` but not `lhs` in the same fashion.
+    let behind = repo
+        .rev_walk([rhs])
+        .with_boundary([lhs])
+        .all()
+        .into_diagnostic()?
+        .filter_map(std::result::Result::ok)
+        .count();
+
+    Ok((ahead, behind))
+}
+
+/// Delete or list local branches fully merged into `HEAD`.
+pub fn cleanup_merged_branches(repo: &gix::Repository, dry_run: bool) -> Result<Vec<String>> {
+    // Determine the commit id of HEAD. Branches pointing to this id are skipped.
+    let head = repo.head_id().into_diagnostic()?;
+    let mut removed = Vec::new();
+
+    // Iterate over all local branches.
+    for r in repo
+        .references()
+        .into_diagnostic()?
+        .local_branches()
+        .into_diagnostic()?
+    {
+        let mut r = r.map_err(|e| miette::Report::msg(e.to_string()))?;
+        let name = r.name().shorten().to_string();
+        // Obtain the object id the branch points to.
+        let id = r.peel_to_id_in_place().into_diagnostic()?;
+
+        // Skip the branch if it's the current HEAD.
+        if id == head {
+            continue;
+        }
+
+        // `merge_base` returns the common ancestor of the two commits. If the
+        // branch tip equals the merge base with HEAD, then it is fully merged.
+        if repo.merge_base(head, id).map(|b| b == id).unwrap_or(false) {
+            if dry_run {
+                // Only report that it would be removed.
+                removed.push(name);
+            } else {
+                // Actually delete the reference and record its name.
+                r.delete().into_diagnostic()?;
+                removed.push(name);
+            }
+        }
+    }
+
+    Ok(removed)
+}

--- a/branch-client/src/sdk/mod.rs
+++ b/branch-client/src/sdk/mod.rs
@@ -1,0 +1,7 @@
+//! Shared helpers used by the `branch-client` CLI.
+//!
+//! The `branch` module provides high level branch operations while `repo`
+//! contains a convenience function for opening a repository.
+
+pub mod branch;
+pub mod repo;

--- a/branch-client/src/sdk/repo.rs
+++ b/branch-client/src/sdk/repo.rs
@@ -1,0 +1,14 @@
+//! Small helper for opening a repository using [`gix`].
+
+use miette::IntoDiagnostic;
+use std::path::Path;
+
+use crate::error::Result;
+
+/// Open the repository located at `path`.
+///
+/// This simply calls [`gix::open`] and converts the error into our
+/// [`miette`] based [`crate::error::Result`] type.
+pub fn open_repo(path: &Path) -> Result<gix::Repository> {
+    gix::open(path).into_diagnostic()
+}

--- a/branch-client/tests/basic.rs
+++ b/branch-client/tests/basic.rs
@@ -1,0 +1,27 @@
+mod common;
+use common::{bin, init_repo};
+use std::process::Command;
+
+#[test]
+fn create_list_delete() {
+    let dir = init_repo();
+    let repo = dir.path();
+    Command::new(bin())
+        .args(["--repo", repo.to_str().unwrap(), "create", "test"])
+        .status()
+        .unwrap();
+    let output = Command::new(bin())
+        .args(["--repo", repo.to_str().unwrap(), "list"])
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&output.stdout).contains("test"));
+    Command::new(bin())
+        .args(["--repo", repo.to_str().unwrap(), "delete", "test"])
+        .status()
+        .unwrap();
+    let output = Command::new(bin())
+        .args(["--repo", repo.to_str().unwrap(), "list"])
+        .output()
+        .unwrap();
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("test"));
+}

--- a/branch-client/tests/common/mod.rs
+++ b/branch-client/tests/common/mod.rs
@@ -1,0 +1,41 @@
+use assert_cmd::cargo::cargo_bin;
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+pub fn init_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    Command::new("git").arg("init").current_dir(repo).output().unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "user"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "user@example.com"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    std::fs::write(repo.join("file"), "a").unwrap();
+    Command::new("git")
+        .args(["add", "file"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    dir
+}
+
+pub fn bin() -> PathBuf {
+    cargo_bin("branch-client")
+}

--- a/branch-client/tests/compare_cleanup.rs
+++ b/branch-client/tests/compare_cleanup.rs
@@ -1,0 +1,73 @@
+mod common;
+use common::{bin, init_repo};
+use std::process::Command;
+
+#[test]
+fn compare_branches() {
+    let dir = init_repo();
+    let repo = dir.path();
+    Command::new("git")
+        .args(["checkout", "-b", "feature"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    std::fs::write(repo.join("f2"), "a").unwrap();
+    Command::new("git")
+        .args(["add", "f2"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "feature commit"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let output = Command::new(bin())
+        .args(["--repo", repo.to_str().unwrap(), "compare", "feature", "master"])
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&output.stdout).contains("ahead 1"));
+}
+
+#[test]
+fn cleanup_branches() {
+    let dir = init_repo();
+    let repo = dir.path();
+    Command::new("git")
+        .args(["checkout", "-b", "feature"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    std::fs::write(repo.join("f2"), "a").unwrap();
+    Command::new("git")
+        .args(["add", "f2"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "feature commit"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["checkout", "master"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["merge", "feature", "--no-edit", "--no-ff"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let output = Command::new(bin())
+        .args(["--repo", repo.to_str().unwrap(), "cleanup", "--dry-run"])
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&output.stdout).contains("would delete feature"));
+    Command::new(bin())
+        .args(["--repo", repo.to_str().unwrap(), "cleanup"])
+        .status()
+        .unwrap();
+    let branches = Command::new("git").args(["branch"]).current_dir(repo).output().unwrap();
+    assert!(!String::from_utf8_lossy(&branches.stdout).contains("feature"));
+}


### PR DESCRIPTION
## Summary
- add `sdk` module with reusable repository and branch helpers
- refactor command handlers to use the new helpers
- expose `error` alias for miette results
- update `main.rs` to use the sdk
- add integration tests for `compare` and `cleanup`
- share test helpers via `tests/common`
- document SDK functions

## Testing
- `cargo build --message-format short -p branch-client`
- `cargo check --message-format short -p branch-client`
- `cargo test --message-format short -p branch-client`
- `cargo clippy --message-format short -p branch-client`
- `cargo run -p branch-client -- --help | head`


------
https://chatgpt.com/codex/tasks/task_e_685c22afa6f083209408c57d6dddfeca