### PR TITLE
Add commit size median metrics

### DIFF
--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -32,6 +32,7 @@ It relies on `gitoxide-core` for heavy lifting and focuses on summarizing how mu
   - `--working-dir` - path to the repository
   - `--rev-spec` - revision to analyze
   - `--percentiles <list>` - show additional percentiles for commit size
+  - `--json` - machine readable output
 - `frecency` — rank files by how recently and frequently they changed.
   - `--working-dir` - path to the repository
   - `--rev-spec` - revision to analyze
@@ -66,8 +67,10 @@ development activity across the repository.
 
 Large commits are harder to review and carry a higher risk of introducing
 problems. Keeping commit sizes small makes code reviews faster and helps isolate
-issues. The `commit-size` command summarizes how much code changes per commit so
-you can gauge the typical review burden and spot unusually large commits.
+issues. Small changes let reviewers focus on the intent of each commit which
+reduces the chances of bugs slipping through. The `commit-size` command
+summarizes how much code changes per commit so you can gauge the typical review
+burden and spot unusually large commits.
 
 ## File Frecency
 

--- a/git-productivity-analyzer/src/sdk/commit_size/analyzer.rs
+++ b/git-productivity-analyzer/src/sdk/commit_size/analyzer.rs
@@ -8,9 +8,11 @@ pub struct Summary {
     pub min_files: u32,
     pub max_files: u32,
     pub avg_files: f64,
+    pub median_files: f64,
     pub min_lines: u32,
     pub max_lines: u32,
     pub avg_lines: f64,
+    pub median_lines: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_percentiles: Option<Vec<(f64, u32)>>,
 }
@@ -77,6 +79,9 @@ impl Analyzer {
         } else {
             files.iter().copied().map(f64::from).sum::<f64>() / files.len() as f64
         };
+        let mut files_sorted = files.clone();
+        files_sorted.sort_unstable();
+        let median_files = median(&files_sorted);
         let min_lines = lines.iter().copied().min().unwrap_or(0);
         let max_lines = lines.iter().copied().max().unwrap_or(0);
         let avg_lines = if lines.is_empty() {
@@ -84,6 +89,9 @@ impl Analyzer {
         } else {
             lines.iter().copied().map(f64::from).sum::<f64>() / lines.len() as f64
         };
+        let mut lines_sorted = lines.clone();
+        lines_sorted.sort_unstable();
+        let median_lines = median(&lines_sorted);
         let line_percentiles = if lines.is_empty() {
             None
         } else {
@@ -98,9 +106,11 @@ impl Analyzer {
             min_files,
             max_files,
             avg_files,
+            median_files,
             min_lines,
             max_lines,
             avg_lines,
+            median_lines,
             line_percentiles,
         }
     }
@@ -108,12 +118,12 @@ impl Analyzer {
     pub fn print_summary(&self, summary: &Summary) {
         crate::sdk::print_json_or(self.globals.json, summary, || {
             println!(
-                "files per commit: min={} max={} avg={:.2}",
-                summary.min_files, summary.max_files, summary.avg_files
+                "files per commit: min={} max={} avg={:.2} median={:.2}",
+                summary.min_files, summary.max_files, summary.avg_files, summary.median_files
             );
             println!(
-                "lines per commit: min={} max={} avg={:.2}",
-                summary.min_lines, summary.max_lines, summary.avg_lines
+                "lines per commit: min={} max={} avg={:.2} median={:.2}",
+                summary.min_lines, summary.max_lines, summary.avg_lines, summary.median_lines
             );
             if let Some(pcts) = &summary.line_percentiles {
                 for (p, value) in pcts {
@@ -121,6 +131,18 @@ impl Analyzer {
                 }
             }
         });
+    }
+}
+
+fn median(values: &[u32]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mid = values.len() / 2;
+    if values.len() % 2 == 1 {
+        values[mid] as f64
+    } else {
+        (values[mid - 1] + values[mid]) as f64 / 2.0
     }
 }
 

--- a/tests/snapshots/commit-size/default
+++ b/tests/snapshots/commit-size/default
@@ -1,2 +1,2 @@
-files per commit: min=1 max=1 avg=1.00
-lines per commit: min=1 max=3 avg=2.00
+files per commit: min=1 max=1 avg=1.00 median=1.00
+lines per commit: min=1 max=3 avg=2.00 median=2.00

--- a/tests/snapshots/commit-size/percentiles
+++ b/tests/snapshots/commit-size/percentiles
@@ -1,4 +1,4 @@
-files per commit: min=1 max=1 avg=1.00
-lines per commit: min=1 max=3 avg=2.00
+files per commit: min=1 max=1 avg=1.00 median=1.00
+lines per commit: min=1 max=3 avg=2.00 median=2.00
 p50 = 2
 p100 = 3


### PR DESCRIPTION
## Summary
- compute medians when analyzing commit size distribution
- print median values
- document JSON output flag for `commit-size` and expand documentation about review risk
- update commit-size snapshots to include median values

## Testing
- `cargo build --message-format short -p git-productivity-analyzer`
- `cargo check --message-format short -p git-productivity-analyzer`
- `cargo test --message-format short -p git-productivity-analyzer`
- `cargo clippy --message-format short -p git-productivity-analyzer`
- `cargo run -p git-productivity-analyzer -- --help ""`
- `bash tests/commit-size.sh > /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_6864706e35a883209587d24c9603eb9c