### PR TITLE
Add commit size median metrics

### DIFF
--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -32,6 +32,7 @@ It relies on `gitoxide-core` for heavy lifting and focuses on summarizing how mu
   - `--working-dir` - path to the repository
   - `--rev-spec` - revision to analyze
   - `--percentiles <list>` - show additional percentiles for commit size
+  - `--json` - machine readable output
 - `frecency` — rank files by how recently and frequently they changed.
   - `--working-dir` - path to the repository
   - `--rev-spec` - revision to analyze
@@ -66,8 +67,25 @@ development activity across the repository.
 
 Large commits are harder to review and carry a higher risk of introducing
 problems. Keeping commit sizes small makes code reviews faster and helps isolate
-issues. The `commit-size` command summarizes how much code changes per commit so
-you can gauge the typical review burden and spot unusually large commits.
+issues. Small changes let reviewers focus on the intent of each commit which
+reduces the chances of bugs slipping through. The `commit-size` command
+summarizes how much code changes per commit so you can gauge the typical review
+burden and spot unusually large commits.
+
+When the `--json` flag is used the output looks like this:
+
+```json
+{
+  "min_files": 1,
+  "max_files": 1,
+  "avg_files": 1.0,
+  "median_files": 1.0,
+  "min_lines": 1,
+  "max_lines": 3,
+  "avg_lines": 2.0,
+  "median_lines": 2.0
+}
+```
 
 ## File Frecency
 

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -87,6 +87,25 @@ When the `--json` flag is used the output looks like this:
 }
 ```
 
+When percentiles are requested as well:
+
+```json
+{
+  "min_files": 1,
+  "max_files": 1,
+  "avg_files": 1.0,
+  "median_files": 1.0,
+  "min_lines": 1,
+  "max_lines": 3,
+  "avg_lines": 2.0,
+  "median_lines": 2.0,
+  "line_percentiles": [
+    [50.0, 2],
+    [100.0, 3]
+  ]
+}
+```
+
 ## File Frecency
 
 `frecency` ranks files by combining the age of commits touching them with the

--- a/git-productivity-analyzer/src/main.rs
+++ b/git-productivity-analyzer/src/main.rs
@@ -7,7 +7,6 @@ mod util;
 
 use crate::error::Result;
 use clap::ValueEnum;
-use env_logger;
 use log::LevelFilter;
 
 /// Shared options available to all subcommands.

--- a/git-productivity-analyzer/src/sdk/frecency/scoring.rs
+++ b/git-productivity-analyzer/src/sdk/frecency/scoring.rs
@@ -14,7 +14,10 @@ impl Analyzer {
 
     /// Check if the given path is included in the filter list.
     pub(super) fn path_allowed(&self, path: &PathBuf) -> bool {
-        self.opts.paths.as_ref().map_or(true, |paths| paths.contains(path))
+        match &self.opts.paths {
+            Some(paths) => paths.contains(path),
+            None => true,
+        }
     }
 
     /// Update the score for a single file path.

--- a/git-productivity-analyzer/src/sdk/mod.rs
+++ b/git-productivity-analyzer/src/sdk/mod.rs
@@ -7,6 +7,7 @@ pub mod frecency;
 mod helpers;
 pub mod hours;
 mod revision;
+pub mod stats;
 pub mod time_of_day;
 
 pub use helpers::{print_json_or, run_with_analyzer, AnalyzerTrait, IntoAnalyzer};

--- a/git-productivity-analyzer/src/sdk/stats.rs
+++ b/git-productivity-analyzer/src/sdk/stats.rs
@@ -1,0 +1,39 @@
+/// Compute the median of a slice of numbers.
+///
+/// The input slice does not need to be sorted; this function will
+/// partially sort a copy internally using [`select_nth_unstable`].
+pub fn median(values: &[u32]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut buf = values.to_vec();
+    let mid = buf.len() / 2;
+    let mid_val = *buf.select_nth_unstable(mid).1;
+    if buf.len() % 2 == 1 {
+        mid_val as f64
+    } else {
+        let lower_val = *buf[..mid].select_nth_unstable(mid - 1).1;
+        (lower_val as f64 + mid_val as f64) / 2.0
+    }
+}
+
+/// Return the percentile `pct` of a sorted slice of numbers.
+///
+/// `pct` must be within `0..=100` and `values` must be sorted in ascending order.
+pub fn percentile_of_sorted(values: &[u32], pct: f64) -> Option<u32> {
+    if values.is_empty() {
+        return None;
+    }
+    assert!((0.0..=100.0).contains(&pct));
+    if (pct - 100.0).abs() < f64::EPSILON || values.len() == 1 {
+        return Some(values.last().copied().unwrap_or_default());
+    }
+    let length = (values.len() - 1) as f64;
+    let rank = (pct / 100.0) * length;
+    let lower = rank.floor();
+    let d = rank - lower;
+    let n = lower as usize;
+    let lo = values[n] as f64;
+    let hi = values[n + 1] as f64;
+    Some((lo + (hi - lo) * d).round() as u32)
+}

--- a/tests/snapshots/commit-size/default
+++ b/tests/snapshots/commit-size/default
@@ -1,2 +1,2 @@
-files per commit: min=1 max=1 avg=1.00
-lines per commit: min=1 max=3 avg=2.00
+files per commit: min=1 max=1 avg=1.00 median=1.00
+lines per commit: min=1 max=3 avg=2.00 median=2.00

--- a/tests/snapshots/commit-size/percentiles
+++ b/tests/snapshots/commit-size/percentiles
@@ -1,4 +1,4 @@
-files per commit: min=1 max=1 avg=1.00
-lines per commit: min=1 max=3 avg=2.00
+files per commit: min=1 max=1 avg=1.00 median=1.00
+lines per commit: min=1 max=3 avg=2.00 median=2.00
 p50 = 2
 p100 = 3


### PR DESCRIPTION
## Summary
- compute medians using `select_nth_unstable`
- share median and percentile helpers in new stats module
- document commit-size JSON output with median fields
- remove redundant sorting before calling median

## Testing
- `cargo build --message-format short -p git-productivity-analyzer`
- `cargo check --message-format short -p git-productivity-analyzer`
- `cargo test --message-format short -p git-productivity-analyzer`
- `cargo clippy --message-format short -p git-productivity-analyzer`
- `cargo run -p git-productivity-analyzer -- --help ""`
- `bash tests/commit-size.sh > /tmp/test.log`
- `scripts/round_trip_test_offline.sh` *(fails: No such file or directory)*
- `scripts/test_utils.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6864706e35a883209587d24c9603eb9c

## Summary by Sourcery

Add median calculation support to the commit-size analyzer by extracting statistical helpers into a new stats module, expose median values in both JSON and CLI outputs, and update documentation and tests accordingly

New Features:
- Add median metrics for files and lines to the commit-size analysis
- Introduce a --json flag for machine-readable commit-size output

Enhancements:
- Extract median and percentile computation into a new stats module using select_nth_unstable
- Include median values in the CLI summary output for commit sizes

Documentation:
- Document the JSON output format in the README to show median and percentile fields

Tests:
- Update commit-size snapshots to include median metrics