### PR TITLE
Add code ownership analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,7 @@ dependencies = [
  "env_logger",
  "gitoxide-core",
  "gix",
+ "glob",
  "log",
  "miette",
  "predicates 2.1.5",

--- a/git-productivity-analyzer/Cargo.toml
+++ b/git-productivity-analyzer/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 bytecount = "0.6"
 log = "0.4"
 env_logger = { version = "0.11", default-features = false }
+glob = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -129,5 +129,5 @@ Configure `RUST_LOG` or the `--log-level` flag to control their visibility.
 
 ## Code Ownership
 
-`ownership` shows what percentage of commits each contributor made per top-level folder.
+`ownership` shows what percentage of commits each contributor made per top-level folder. Files in the repository root are grouped under the `.` directory.
 This helps identify experts for specific modules and highlights areas with a high bus factor.

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -131,4 +131,5 @@ Configure `RUST_LOG` or the `--log-level` flag to control their visibility.
 ## Code Ownership
 
 `ownership` shows what percentage of commits each contributor made per directory. The `--depth` option controls how many path segments are used when grouping files. Files in the repository root are always grouped under the `.` directory.
+Merge commits are compared against their first parent only. Changes are counted per file and aggregated by directory. Authors are sorted by descending percentage with alphabetical ordering used to break ties.
 This helps identify experts for specific modules and highlights areas with a high bus factor.

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -48,8 +48,9 @@ It relies on `gitoxide-core` for heavy lifting and focuses on summarizing how mu
 - `ownership` — summarize code ownership by directory.
   - `--working-dir` - path to the repository
   - `--rev-spec` - revision to analyze
-  - `--path <glob>` - only consider paths matching this pattern
-  - `--author <pattern>` - filter commits by author
+- `--path <glob>` - only consider paths matching this pattern
+- `--author <pattern>` - filter commits by author
+  - `--depth <n>` - number of path segments to group by
   - `--json` - machine readable output
 
 All commands accept the global options `--since <date>`, `--until <date>`, `--json`, and `--log-level <level>` to limit the date range, choose output format, and control verbosity.
@@ -129,5 +130,5 @@ Configure `RUST_LOG` or the `--log-level` flag to control their visibility.
 
 ## Code Ownership
 
-`ownership` shows what percentage of commits each contributor made per top-level folder. Files in the repository root are grouped under the `.` directory.
+`ownership` shows what percentage of commits each contributor made per directory. The `--depth` option controls how many path segments are used when grouping files. Files in the repository root are always grouped under the `.` directory.
 This helps identify experts for specific modules and highlights areas with a high bus factor.

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -130,6 +130,6 @@ Configure `RUST_LOG` or the `--log-level` flag to control their visibility.
 
 ## Code Ownership
 
-`ownership` shows what percentage of commits each contributor made per directory. The `--depth` option controls how many path segments are used when grouping files. Files in the repository root are always grouped under the `.` directory.
+`ownership` shows what percentage of commits each contributor made per directory. The `--depth` option controls how many path segments are used when grouping files. Using `--depth 0` groups all files together. Files in the repository root are always grouped under the `.` directory.
 Merge commits are compared against their first parent only. Changes are counted per file and aggregated by directory. Authors are sorted by descending percentage with alphabetical ordering used to break ties.
 This helps identify experts for specific modules and highlights areas with a high bus factor.

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -45,6 +45,12 @@ It relies on `gitoxide-core` for heavy lifting and focuses on summarizing how mu
 - `--path-only` - print only file paths
 - merge commits are skipped when tallying file scores
  - when multiple files have the same score they are sorted alphabetically to keep output stable
+- `ownership` — summarize code ownership by directory.
+  - `--working-dir` - path to the repository
+  - `--rev-spec` - revision to analyze
+  - `--path <glob>` - only consider paths matching this pattern
+  - `--author <pattern>` - filter commits by author
+  - `--json` - machine readable output
 
 All commands accept the global options `--since <date>`, `--until <date>`, `--json`, and `--log-level <level>` to limit the date range, choose output format, and control verbosity.
 
@@ -120,3 +126,8 @@ Entries with identical scores are ordered alphabetically so results are
 stable across runs.
 Warnings encountered during analysis are emitted using the `log` crate.
 Configure `RUST_LOG` or the `--log-level` flag to control their visibility.
+
+## Code Ownership
+
+`ownership` shows what percentage of commits each contributor made per top-level folder.
+This helps identify experts for specific modules and highlights areas with a high bus factor.

--- a/git-productivity-analyzer/src/cmd/mod.rs
+++ b/git-productivity-analyzer/src/cmd/mod.rs
@@ -4,6 +4,7 @@ pub mod commit_size;
 pub mod common;
 pub mod frecency;
 pub mod hours;
+pub mod ownership;
 pub mod time_of_day;
 
 use clap::Subcommand;
@@ -22,4 +23,6 @@ pub enum Command {
     CommitSize(commit_size::Args),
     #[command(about = "Score files by recent change frequency")]
     Frecency(frecency::Args),
+    #[command(about = "Summarize code ownership by directory")]
+    Ownership(ownership::Args),
 }

--- a/git-productivity-analyzer/src/cmd/ownership/args.rs
+++ b/git-productivity-analyzer/src/cmd/ownership/args.rs
@@ -11,6 +11,13 @@ pub struct Args {
 
     #[arg(long, help = "Only count commits whose author matches this pattern.")]
     pub author: Option<String>,
+
+    #[arg(
+        long,
+        default_value_t = 1,
+        help = "Number of path segments to group by when summarizing ownership."
+    )]
+    pub depth: usize,
 }
 
-crate::impl_from_args!(Args, crate::sdk::ownership::Options { path, author });
+crate::impl_from_args!(Args, crate::sdk::ownership::Options { path, author, depth });

--- a/git-productivity-analyzer/src/cmd/ownership/args.rs
+++ b/git-productivity-analyzer/src/cmd/ownership/args.rs
@@ -1,0 +1,16 @@
+use crate::cmd::common::CommonArgs;
+use clap::{Args as ClapArgs, ValueHint};
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    #[command(flatten)]
+    pub common: CommonArgs,
+
+    #[arg(long, value_hint = ValueHint::FilePath, help = "Only include paths matching this glob")]
+    pub path: Option<String>,
+
+    #[arg(long, help = "Only count commits whose author matches this pattern.")]
+    pub author: Option<String>,
+}
+
+crate::impl_from_args!(Args, crate::sdk::ownership::Options { path, author });

--- a/git-productivity-analyzer/src/cmd/ownership/args.rs
+++ b/git-productivity-analyzer/src/cmd/ownership/args.rs
@@ -15,7 +15,7 @@ pub struct Args {
     #[arg(
         long,
         default_value_t = 1,
-        help = "Number of path segments to group by when summarizing ownership."
+        help = "Number of path segments to group by when summarizing ownership.\nUse 0 to group all files together."
     )]
     pub depth: usize,
 }

--- a/git-productivity-analyzer/src/cmd/ownership/mod.rs
+++ b/git-productivity-analyzer/src/cmd/ownership/mod.rs
@@ -1,0 +1,5 @@
+mod args;
+mod run;
+
+pub use args::Args;
+pub use run::run;

--- a/git-productivity-analyzer/src/cmd/ownership/run.rs
+++ b/git-productivity-analyzer/src/cmd/ownership/run.rs
@@ -1,0 +1,9 @@
+use super::args::Args;
+use crate::error::Result;
+use crate::sdk::{ownership::Options, run_with_analyzer};
+use crate::Globals;
+
+pub async fn run(args: Args, globals: &Globals) -> Result<()> {
+    let opts: Options = args.into();
+    run_with_analyzer(opts, globals, |a, totals| a.print_totals(totals)).await
+}

--- a/git-productivity-analyzer/src/main.rs
+++ b/git-productivity-analyzer/src/main.rs
@@ -78,5 +78,6 @@ async fn main() -> Result<()> {
         cmd::Command::Churn(args) => cmd::churn::run(args, &globals).await,
         cmd::Command::CommitSize(args) => cmd::commit_size::run(args, &globals).await,
         cmd::Command::Frecency(args) => cmd::frecency::run(args, &globals).await,
+        cmd::Command::Ownership(args) => cmd::ownership::run(args, &globals).await,
     }
 }

--- a/git-productivity-analyzer/src/sdk/mod.rs
+++ b/git-productivity-analyzer/src/sdk/mod.rs
@@ -4,6 +4,7 @@ pub mod commit_size;
 mod common;
 pub mod diff;
 pub mod frecency;
+pub mod ownership;
 mod helpers;
 pub mod hours;
 mod revision;

--- a/git-productivity-analyzer/src/sdk/ownership/analyzer.rs
+++ b/git-productivity-analyzer/src/sdk/ownership/analyzer.rs
@@ -1,0 +1,125 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{error::Result, Globals};
+use glob::Pattern;
+use miette::IntoDiagnostic;
+use gix::bstr::ByteSlice;
+
+#[derive(Clone)]
+pub struct Options {
+    pub repo: crate::sdk::RepoOptions,
+    pub path: Option<String>,
+    pub author: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct Analyzer {
+    opts: Options,
+    globals: Globals,
+}
+
+pub type Totals = BTreeMap<String, BTreeMap<String, u32>>;
+
+crate::impl_analyzer_boilerplate!(Options, Analyzer);
+
+impl Analyzer {
+    pub fn analyze(self) -> Result<Totals> {
+        let (repo, start, since) = crate::sdk::open_with_range(&self.opts.repo, &self.globals)?;
+        let pattern = match &self.opts.path {
+            Some(p) => Some(Pattern::new(p).map_err(|e| miette::miette!(e.to_string()))?),
+            None => None,
+        };
+        let mut totals = BTreeMap::<String, BTreeMap<String, u32>>::new();
+        crate::sdk::walk_commits(&repo, start, since.as_ref(), false, |id, commit| {
+            let author = commit.author().into_diagnostic()?;
+            if !crate::sdk::author_matches(&author, &self.opts.author) {
+                return Ok(());
+            }
+            let author_string = format!("{} <{}>", author.name, author.email);
+            self.process_commit(&repo, id, &commit, pattern.as_ref(), &author_string, &mut totals)
+        })?;
+        Ok(totals)
+    }
+
+    fn process_commit(
+        &self,
+        repo: &gix::Repository,
+        id: gix::ObjectId,
+        commit: &gix::Commit<'_>,
+        pattern: Option<&Pattern>,
+        author: &str,
+        totals: &mut Totals,
+    ) -> Result<()> {
+        let parent = commit.parent_ids().next().map(|p| p.detach());
+        let (from, to) = crate::sdk::diff::commit_trees(repo, id, parent);
+        let mut changes = crate::sdk::diff::create_changes(&from)?;
+        crate::sdk::diff::configure_changes(&mut changes);
+        let mut dirs = BTreeSet::new();
+        changes
+            .for_each_to_obtain_tree(&to, |change| {
+                use gix::object::tree::diff::Change::*;
+                let location = match change {
+                    Addition { location, .. }
+                    | Deletion { location, .. }
+                    | Modification { location, .. } => location,
+                    Rewrite { location, .. } => location,
+                };
+                let path = location.to_str_lossy();
+                if let Some(pat) = pattern {
+                    if !pat.matches(&path) {
+                        return Ok::<_, std::convert::Infallible>(gix::object::tree::diff::Action::Continue);
+                    }
+                }
+                let dir = path.split('/').next().unwrap_or("");
+                let dir = if dir.is_empty() { "." } else { dir };
+                dirs.insert(dir.to_string());
+                Ok::<_, std::convert::Infallible>(gix::object::tree::diff::Action::Continue)
+            })
+            .into_diagnostic()?;
+        for dir in dirs {
+            let by_author = totals.entry(dir).or_default();
+            *by_author.entry(author.to_string()).or_default() += 1;
+        }
+        Ok(())
+    }
+
+    pub fn print_totals(&self, totals: &Totals) {
+        crate::sdk::print_json_or(self.globals.json, &SerializableTotals::from(totals), || {
+            for (dir, counts) in totals {
+                let total: u32 = counts.values().sum();
+                print!("{dir}: ");
+                let mut parts = Vec::new();
+                for (author, count) in counts {
+                    let pct = (*count as f64) * 100.0 / total as f64;
+                    parts.push(format!("{author} {:.0}%", pct));
+                }
+                println!("{}", parts.join(" "));
+            }
+        });
+    }
+}
+
+#[derive(serde::Serialize)]
+struct SerializableTotals(BTreeMap<String, BTreeMap<String, f64>>);
+
+impl From<&Totals> for SerializableTotals {
+    fn from(t: &Totals) -> Self {
+        let mut out = BTreeMap::new();
+        for (dir, counts) in t {
+            let total: u32 = counts.values().sum();
+            let mut percents = BTreeMap::new();
+            for (author, count) in counts {
+                percents.insert(author.clone(), (*count as f64) * 100.0 / total as f64);
+            }
+            out.insert(dir.clone(), percents);
+        }
+        SerializableTotals(out)
+    }
+}
+
+impl crate::sdk::AnalyzerTrait for Analyzer {
+    type Output = Totals;
+    fn analyze(self) -> crate::error::Result<Self::Output> {
+        Analyzer::analyze(self)
+    }
+}

--- a/git-productivity-analyzer/src/sdk/ownership/mod.rs
+++ b/git-productivity-analyzer/src/sdk/ownership/mod.rs
@@ -1,0 +1,3 @@
+mod analyzer;
+
+pub use analyzer::Options;

--- a/tests/code-ownership.sh
+++ b/tests/code-ownership.sh
@@ -16,6 +16,9 @@ snapshot="$SCRIPT_DIR/snapshots/code-ownership"
       git config commit.gpgsign false &&
       git config tag.gpgsign false &&
       mkdir src docs &&
+      echo root > README && git add README && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m root &&
       echo a > src/a && git add src/a && \
       GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
       GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m init &&

--- a/tests/code-ownership.sh
+++ b/tests/code-ownership.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eu -o pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+source "$SCRIPT_DIR/utilities.sh"
+SUCCESSFULLY=0
+
+snapshot="$SCRIPT_DIR/snapshots/code-ownership"
+
+(title "code-ownership" && \
+  repo_root="$PWD" && \
+  (
+    sandbox && (
+      git init &&
+      git checkout -b main &&
+      git config commit.gpgsign false &&
+      git config tag.gpgsign false &&
+      mkdir src docs &&
+      echo a > src/a && git add src/a && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m init &&
+      echo b > docs/b && git add docs/b && \
+      GIT_AUTHOR_NAME="Bob" GIT_AUTHOR_EMAIL=b@example.com \
+      GIT_COMMITTER_NAME="Bob" GIT_COMMITTER_EMAIL=b@example.com git commit -m docs &&
+      echo more >> src/a && git add src/a && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m change
+    )
+    export REPO_ROOT="$repo_root"
+    it "prints ownership percentages" && {
+      WITH_SNAPSHOT="$snapshot/default" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" 2>/dev/null)"
+    }
+    it "prints ownership in JSON" && {
+      WITH_SNAPSHOT="$snapshot/json" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- --json ownership --working-dir \"$PWD\" 2>/dev/null)"
+    }
+  )
+)

--- a/tests/code-ownership.sh
+++ b/tests/code-ownership.sh
@@ -49,6 +49,30 @@ snapshot="$SCRIPT_DIR/snapshots/code-ownership"
   )
 )
 
+(title "code-ownership-depth-zero" && \
+  repo_root="$PWD" && \
+  (
+    sandbox && (
+      git init &&
+      git checkout -b main &&
+      git config commit.gpgsign false &&
+      git config tag.gpgsign false &&
+      mkdir one two &&
+      echo x > one/a && git add one/a && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m one &&
+      echo y > two/b && git add two/b && \
+      GIT_AUTHOR_NAME="Bob" GIT_AUTHOR_EMAIL=b@example.com \
+      GIT_COMMITTER_NAME="Bob" GIT_COMMITTER_EMAIL=b@example.com git commit -m two
+    )
+    export REPO_ROOT="$repo_root"
+    it "groups everything when depth is zero" && {
+      WITH_SNAPSHOT="$snapshot/depth-zero" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" --depth 0 2>/dev/null)"
+    }
+  )
+)
+
 (title "code-ownership-root-only" && \
   repo_root="$PWD" && \
   (

--- a/tests/code-ownership.sh
+++ b/tests/code-ownership.sh
@@ -42,9 +42,74 @@ snapshot="$SCRIPT_DIR/snapshots/code-ownership"
       WITH_SNAPSHOT="$snapshot/path" \
       expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" --path 'src/*' 2>/dev/null)"
     }
-    it "filters by author" && {
-      WITH_SNAPSHOT="$snapshot/author" \
-      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" --author Alice 2>/dev/null)"
+  it "filters by author" && {
+    WITH_SNAPSHOT="$snapshot/author" \
+    expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" --author Alice 2>/dev/null)"
+  }
+  )
+)
+
+(title "code-ownership-root-only" && \
+  repo_root="$PWD" && \
+  (
+    sandbox && (
+      git init &&
+      git checkout -b main &&
+      git config commit.gpgsign false &&
+      git config tag.gpgsign false &&
+      echo one > A && git add A && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m A &&
+      echo two > B && git add B && \
+      GIT_AUTHOR_NAME="Bob" GIT_AUTHOR_EMAIL=b@example.com \
+      GIT_COMMITTER_NAME="Bob" GIT_COMMITTER_EMAIL=b@example.com git commit -m B
+    )
+    export REPO_ROOT="$repo_root"
+    it "groups root files and orders authors" && {
+      WITH_SNAPSHOT="$snapshot/root-only" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" 2>/dev/null)"
+    }
+  )
+)
+
+(title "code-ownership-no-matches" && \
+  repo_root="$PWD" && \
+  (
+    sandbox && (
+      git init &&
+      git checkout -b main &&
+      git config commit.gpgsign false &&
+      git config tag.gpgsign false &&
+      mkdir src && echo hi > src/a && git add src/a && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m init
+    )
+    export REPO_ROOT="$repo_root"
+    it "handles path filter with no matches" && {
+      WITH_SNAPSHOT="$snapshot/no-path" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" --path 'none*' 2>/dev/null)"
+    }
+    it "handles author filter with no matches" && {
+      WITH_SNAPSHOT="$snapshot/no-author" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" --author Carol 2>/dev/null)"
+    }
+  )
+)
+
+(title "code-ownership-empty" && \
+  repo_root="$PWD" && \
+  (
+    sandbox && (
+      git init &&
+      git checkout -b main &&
+      git config commit.gpgsign false &&
+      git config tag.gpgsign false
+    )
+    export REPO_ROOT="$repo_root"
+    it "fails on empty repository" && {
+      WITH_SNAPSHOT="$snapshot/empty" \
+      SNAPSHOT_FILTER="$SCRIPT_DIR/filters/last-line.sh" \
+      expect_run_sh 1 "(cd \"$REPO_ROOT\" && cargo run-short -q -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" 2>&1)"
     }
   )
 )

--- a/tests/code-ownership.sh
+++ b/tests/code-ownership.sh
@@ -38,5 +38,13 @@ snapshot="$SCRIPT_DIR/snapshots/code-ownership"
       WITH_SNAPSHOT="$snapshot/json" \
       expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- --json ownership --working-dir \"$PWD\" 2>/dev/null)"
     }
+    it "filters by path" && {
+      WITH_SNAPSHOT="$snapshot/path" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" --path 'src/*' 2>/dev/null)"
+    }
+    it "filters by author" && {
+      WITH_SNAPSHOT="$snapshot/author" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- ownership --working-dir \"$PWD\" --author Alice 2>/dev/null)"
+    }
   )
 )

--- a/tests/filters/last-line.sh
+++ b/tests/filters/last-line.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Print the last non-empty line of input
+awk 'NF{line=$0} END{print line}'

--- a/tests/snapshots/code-ownership/author
+++ b/tests/snapshots/code-ownership/author
@@ -1,0 +1,2 @@
+.: Alice <a@example.com> 100%
+src: Alice <a@example.com> 100%

--- a/tests/snapshots/code-ownership/default
+++ b/tests/snapshots/code-ownership/default
@@ -1,2 +1,3 @@
+.: Alice <a@example.com> 100%
 docs: Bob <b@example.com> 100%
 src: Alice <a@example.com> 100%

--- a/tests/snapshots/code-ownership/default
+++ b/tests/snapshots/code-ownership/default
@@ -1,0 +1,2 @@
+docs: Bob <b@example.com> 100%
+src: Alice <a@example.com> 100%

--- a/tests/snapshots/code-ownership/depth-zero
+++ b/tests/snapshots/code-ownership/depth-zero
@@ -1,0 +1,1 @@
+.: Alice <a@example.com> 50% Bob <b@example.com> 50%

--- a/tests/snapshots/code-ownership/empty
+++ b/tests/snapshots/code-ownership/empty
@@ -1,0 +1,1 @@
+Error:   × The rev-spec is malformed and misses a ref name

--- a/tests/snapshots/code-ownership/json
+++ b/tests/snapshots/code-ownership/json
@@ -1,1 +1,1 @@
-{"docs":{"Bob <b@example.com>":100.0},"src":{"Alice <a@example.com>":100.0}}
+{".":{"Alice <a@example.com>":100.0},"docs":{"Bob <b@example.com>":100.0},"src":{"Alice <a@example.com>":100.0}}

--- a/tests/snapshots/code-ownership/json
+++ b/tests/snapshots/code-ownership/json
@@ -1,0 +1,1 @@
+{"docs":{"Bob <b@example.com>":100.0},"src":{"Alice <a@example.com>":100.0}}

--- a/tests/snapshots/code-ownership/path
+++ b/tests/snapshots/code-ownership/path
@@ -1,0 +1,1 @@
+src: Alice <a@example.com> 100%

--- a/tests/snapshots/code-ownership/root-only
+++ b/tests/snapshots/code-ownership/root-only
@@ -1,0 +1,1 @@
+.: Alice <a@example.com> 50% Bob <b@example.com> 50%


### PR DESCRIPTION
## Summary
- support a new `ownership` subcommand in git-productivity-analyzer
- compute commit percentages per directory and print in human or JSON form
- document the new command and its purpose
- cover the feature with an end-to-end test

## Testing
- `cargo build-short -p git-productivity-analyzer`
- `cargo check-short -p git-productivity-analyzer`
- `cargo test-short -p git-productivity-analyzer`
- `cargo clippy-short -p git-productivity-analyzer` *(fails: `cargo-clippy` not installed)*
- `cargo run -p git-productivity-analyzer -- --help ""`
- `bash tests/code-ownership.sh`

------
https://chatgpt.com/codex/tasks/task_e_68648fcbf6dc83209f45c4044ed86b97

## Summary by Sourcery

Add a new `ownership` subcommand to the git-productivity-analyzer to compute and report code ownership percentages per directory, with options for depth-based grouping, path and author filtering, and JSON output.

New Features:
- Introduce `ownership` subcommand to summarize commit percentages by directory with depth grouping and JSON support.
- Support filtering by file path glob and author pattern in the ownership analysis.

Enhancements:
- Register and integrate the ownership analyzer module into the CLI command registry and SDK.
- Add `glob` crate dependency to enable path pattern matching.

Documentation:
- Document the `ownership` command, its flags, and behavior in the README.

Tests:
- Add end-to-end tests covering various ownership scenarios, including default, JSON output, path and author filters, depth-zero grouping, root-only grouping, no matches, and empty repository error.