### PR TITLE
Add commit streak analyzer

### DIFF
--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -18,6 +18,10 @@ It relies on `gitoxide-core` for heavy lifting and focuses on summarizing how mu
   - `--working-dir` - path to the repository
   - `--rev-spec` - revision to analyze
   - `--author <pattern>` - filter commits by author
+- `streaks` — longest consecutive days with a commit per author.
+  - `--working-dir` - path to the repository
+  - `--rev-spec` - revision to analyze
+  - `--author <pattern>` - filter commits by author
 - `time-of-day` — show a histogram of commit times across a 24h day.
   - `--working-dir` - path to the repository
   - `--rev-spec` - revision to analyze
@@ -56,6 +60,7 @@ The implementation is based on `gitoxide-core::hours::estimate_hours()` which gr
 
 Commit frequency helps gauge how busy contributors are and how engaged they remain over time. Regular commits across many days indicate an active developer whereas sparse contributions may show less involvement. Weekly totals can highlight periods of intense activity or lulls.
 Analyzing the commit time of day reveals when individuals typically work, helping to infer personal or team schedules and preferred collaboration windows.
+Streak lengths show how consistently someone contributes. Very long streaks may indicate dedication but could also hint at burnout risk when breaks are rare.
 
 ## Code Churn & Refactoring Insight
 

--- a/git-productivity-analyzer/src/cmd/mod.rs
+++ b/git-productivity-analyzer/src/cmd/mod.rs
@@ -4,6 +4,7 @@ pub mod commit_size;
 pub mod common;
 pub mod frecency;
 pub mod hours;
+pub mod streaks;
 pub mod time_of_day;
 
 use clap::Subcommand;
@@ -22,4 +23,6 @@ pub enum Command {
     CommitSize(commit_size::Args),
     #[command(about = "Score files by recent change frequency")]
     Frecency(frecency::Args),
+    #[command(about = "Longest consecutive commit day streaks")]
+    Streaks(streaks::Args),
 }

--- a/git-productivity-analyzer/src/cmd/streaks/args.rs
+++ b/git-productivity-analyzer/src/cmd/streaks/args.rs
@@ -1,0 +1,13 @@
+use crate::cmd::common::CommonArgs;
+use clap::Args as ClapArgs;
+
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    #[command(flatten)]
+    pub common: CommonArgs,
+
+    #[arg(long, help = "Only count commits whose author matches this pattern.")]
+    pub author: Option<String>,
+}
+
+crate::impl_from_args!(Args, crate::sdk::streaks::Options { author });

--- a/git-productivity-analyzer/src/cmd/streaks/args.rs
+++ b/git-productivity-analyzer/src/cmd/streaks/args.rs
@@ -6,7 +6,10 @@ pub struct Args {
     #[command(flatten)]
     pub common: CommonArgs,
 
-    #[arg(long, help = "Only count commits whose author matches this pattern.")]
+    #[arg(
+        long,
+        help = "Only count commits whose author contains this substring (case-insensitive)."
+    )]
     pub author: Option<String>,
 }
 

--- a/git-productivity-analyzer/src/cmd/streaks/mod.rs
+++ b/git-productivity-analyzer/src/cmd/streaks/mod.rs
@@ -1,0 +1,5 @@
+mod args;
+mod run;
+
+pub use args::Args;
+pub use run::run;

--- a/git-productivity-analyzer/src/cmd/streaks/run.rs
+++ b/git-productivity-analyzer/src/cmd/streaks/run.rs
@@ -1,0 +1,9 @@
+use super::args::Args;
+use crate::error::Result;
+use crate::sdk::{run_with_analyzer, streaks::Options};
+use crate::Globals;
+
+pub async fn run(args: Args, globals: &Globals) -> Result<()> {
+    let opts: Options = args.into();
+    run_with_analyzer(opts, globals, |a, streaks| a.print_streaks(streaks)).await
+}

--- a/git-productivity-analyzer/src/main.rs
+++ b/git-productivity-analyzer/src/main.rs
@@ -78,5 +78,6 @@ async fn main() -> Result<()> {
         cmd::Command::Churn(args) => cmd::churn::run(args, &globals).await,
         cmd::Command::CommitSize(args) => cmd::commit_size::run(args, &globals).await,
         cmd::Command::Frecency(args) => cmd::frecency::run(args, &globals).await,
+        cmd::Command::Streaks(args) => cmd::streaks::run(args, &globals).await,
     }
 }

--- a/git-productivity-analyzer/src/sdk/helpers.rs
+++ b/git-productivity-analyzer/src/sdk/helpers.rs
@@ -62,8 +62,10 @@ macro_rules! impl_analyzer_boilerplate {
 pub fn author_matches(author: &gix::actor::SignatureRef<'_>, filter: &Option<String>) -> bool {
     match filter {
         Some(pattern) => {
-            let pat = pattern.as_str();
-            author.name.to_str_lossy().contains(pat) || author.email.to_str_lossy().contains(pat)
+            let pat = pattern.to_lowercase();
+            let name = author.name.to_str_lossy().to_lowercase();
+            let email = author.email.to_str_lossy().to_lowercase();
+            name.contains(&pat) || email.contains(&pat)
         }
         None => true,
     }

--- a/git-productivity-analyzer/src/sdk/mod.rs
+++ b/git-productivity-analyzer/src/sdk/mod.rs
@@ -8,6 +8,7 @@ mod helpers;
 pub mod hours;
 mod revision;
 pub mod stats;
+pub mod streaks;
 pub mod time_of_day;
 
 pub use helpers::{print_json_or, run_with_analyzer, AnalyzerTrait, IntoAnalyzer};

--- a/git-productivity-analyzer/src/sdk/streaks/analyzer.rs
+++ b/git-productivity-analyzer/src/sdk/streaks/analyzer.rs
@@ -1,0 +1,88 @@
+use chrono::NaiveDate;
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::processor::process_commit;
+use crate::{error::Result, Globals};
+
+pub type Streaks = BTreeMap<String, u32>;
+
+#[derive(Clone)]
+pub struct Options {
+    pub repo: crate::sdk::RepoOptions,
+    pub author: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct Analyzer {
+    opts: Options,
+    globals: Globals,
+}
+
+impl Analyzer {
+    pub fn analyze(self) -> Result<Streaks> {
+        let (repo, start, since) = crate::sdk::open_with_range(&self.opts.repo, &self.globals)?;
+        let mut days_by_author = BTreeMap::<String, BTreeSet<NaiveDate>>::new();
+        self.walk_commits(&repo, start, since.as_ref(), &mut days_by_author)?;
+
+        Ok(days_by_author
+            .into_iter()
+            .map(|(author, days)| (author, longest_streak(&days)))
+            .collect())
+    }
+
+    fn walk_commits(
+        &self,
+        repo: &gix::Repository,
+        start: gix::ObjectId,
+        since: Option<&gix::ObjectId>,
+        by_author: &mut BTreeMap<String, BTreeSet<NaiveDate>>,
+    ) -> Result<()> {
+        crate::sdk::walk_commits(repo, start, since, false, |_, commit| {
+            process_commit(commit, &self.opts.author, by_author)
+        })
+    }
+
+    pub fn print_streaks(&self, streaks: &Streaks) {
+        crate::sdk::print_json_or(self.globals.json, &SerializableStreaks::from(streaks), || {
+            for (author, days) in streaks {
+                println!("{author}: {days}");
+            }
+        });
+    }
+}
+
+fn longest_streak(days: &BTreeSet<NaiveDate>) -> u32 {
+    let mut max = 0;
+    let mut current = 0;
+    let mut prev: Option<NaiveDate> = None;
+    for day in days {
+        if matches!(prev, Some(p) if p.succ_opt() == Some(*day)) {
+            current += 1;
+        } else {
+            current = 1;
+        }
+        max = max.max(current);
+        prev = Some(*day);
+    }
+    max
+}
+
+#[derive(serde::Serialize)]
+struct SerializableStreaks {
+    streaks: BTreeMap<String, u32>,
+}
+
+impl From<&Streaks> for SerializableStreaks {
+    fn from(map: &Streaks) -> Self {
+        Self { streaks: map.clone() }
+    }
+}
+
+crate::impl_analyzer_boilerplate!(Options, Analyzer);
+
+impl crate::sdk::AnalyzerTrait for Analyzer {
+    type Output = Streaks;
+    fn analyze(self) -> crate::error::Result<Self::Output> {
+        Analyzer::analyze(self)
+    }
+}

--- a/git-productivity-analyzer/src/sdk/streaks/mod.rs
+++ b/git-productivity-analyzer/src/sdk/streaks/mod.rs
@@ -1,0 +1,4 @@
+pub mod analyzer;
+mod processor;
+
+pub use analyzer::Options;

--- a/git-productivity-analyzer/src/sdk/streaks/processor.rs
+++ b/git-productivity-analyzer/src/sdk/streaks/processor.rs
@@ -1,0 +1,23 @@
+use chrono::NaiveDate;
+use miette::IntoDiagnostic;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::error::Result;
+
+pub(crate) fn process_commit(
+    commit: gix::Commit<'_>,
+    author_filter: &Option<String>,
+    by_author: &mut BTreeMap<String, BTreeSet<NaiveDate>>,
+) -> Result<()> {
+    let author = commit.author().into_diagnostic()?;
+    if !crate::sdk::author_matches(&author, author_filter) {
+        return Ok(());
+    }
+    let ts = author.seconds();
+    let date = chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
+        .ok_or_else(|| miette::miette!("invalid timestamp {ts}"))?
+        .date_naive();
+    let key = format!("{} <{}>", author.name, author.email);
+    by_author.entry(key).or_default().insert(date);
+    Ok(())
+}

--- a/tests/snapshots/streaks/default
+++ b/tests/snapshots/streaks/default
@@ -1,0 +1,2 @@
+Alice <a@example.com>: 3
+Bob <b@example.com>: 1

--- a/tests/snapshots/streaks/filtered
+++ b/tests/snapshots/streaks/filtered
@@ -1,0 +1,1 @@
+Alice <a@example.com>: 3

--- a/tests/streaks.sh
+++ b/tests/streaks.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eu -o pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+source "$SCRIPT_DIR/utilities.sh"
+SUCCESSFULLY=0
+
+snapshot="$SCRIPT_DIR/snapshots/streaks"
+
+(title "streaks" && \
+  repo_root="$PWD" && \
+  (
+    sandbox && (
+      git init &&
+      git checkout -b main &&
+      git config commit.gpgsign false &&
+      git config tag.gpgsign false &&
+      echo a > a && git add a && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m a1 --date "2020-01-01T00:00:00 +0000" &&
+      echo a >> a && git add a && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m a2 --date "2020-01-02T00:00:00 +0000" &&
+      echo a >> a && git add a && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m a3 --date "2020-01-03T00:00:00 +0000" &&
+      echo b > b && git add b && \
+      GIT_AUTHOR_NAME="Bob" GIT_AUTHOR_EMAIL=b@example.com \
+      GIT_COMMITTER_NAME="Bob" GIT_COMMITTER_EMAIL=b@example.com git commit -m b1 --date "2020-01-01T00:00:00 +0000" &&
+      echo b >> b && git add b && \
+      GIT_AUTHOR_NAME="Bob" GIT_AUTHOR_EMAIL=b@example.com \
+      GIT_COMMITTER_NAME="Bob" GIT_COMMITTER_EMAIL=b@example.com git commit -m b2 --date "2020-01-04T00:00:00 +0000" &&
+      echo a >> a && git add a && \
+      GIT_AUTHOR_NAME="Alice" GIT_AUTHOR_EMAIL=a@example.com \
+      GIT_COMMITTER_NAME="Alice" GIT_COMMITTER_EMAIL=a@example.com git commit -m a4 --date "2020-01-05T00:00:00 +0000"
+    )
+    export REPO_ROOT="$repo_root"
+    it "prints streaks" && {
+      WITH_SNAPSHOT="$snapshot/default" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- streaks --working-dir \"$PWD\" 2>/dev/null)"
+    }
+    it "filters author" && {
+      WITH_SNAPSHOT="$snapshot/filtered" \
+      expect_run_sh $SUCCESSFULLY "(cd \"$REPO_ROOT\" && cargo run-short -p git-productivity-analyzer -- streaks --working-dir \"$PWD\" --author Alice 2>/dev/null)"
+    }
+  )
+)


### PR DESCRIPTION
## Summary
- implement `streaks` command in git-productivity-analyzer
- support author filtering and JSON output
- document new command and explain burnout risk
- provide end-to-end test with snapshots

## Testing
- `cargo check --message-format short -p git-productivity-analyzer`
- `cargo build --message-format short -p git-productivity-analyzer`
- `cargo test --message-format short -p git-productivity-analyzer`
- `cargo clippy --message-format short -p git-productivity-analyzer`
- `cargo run -p git-productivity-analyzer -- --help ""`
- `bash tests/streaks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6864954ebc048320be6597329ded8b81

## Summary by Sourcery

Add a new `streaks` analyzer command to report each author’s longest consecutive daily commit streak, with support for case-insensitive author filtering and JSON output.

New Features:
- Introduce the `streaks` CLI command to compute authors’ longest consecutive commit-day streaks.
- Support case-insensitive author filtering and JSON output for the streaks command.

Enhancements:
- Make author name/email matching case-insensitive across filters.

Documentation:
- Document the new `streaks` command in the README and explain burnout risk from unusually long streaks.

Tests:
- Add end-to-end shell tests with snapshots to validate default and filtered streaks outputs.