### PR TITLE
Add analyzer examples and tests

### DIFF
--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -213,3 +213,7 @@ Execute all end-to-end checks with:
 cargo test-short -p git-productivity-analyzer
 ```
 
+The `test-short` and `check-short` commands are convenience aliases defined in
+`.cargo/config.toml` to run `cargo test --message-format short` and
+`cargo check --message-format short` respectively.
+

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -59,6 +59,72 @@ It relies on `gitoxide-core` for heavy lifting and focuses on summarizing how mu
 
 All commands accept the global options `--since <date>`, `--until <date>`, `--json`, and `--log-level <level>` to limit the date range, choose output format, and control verbosity.
 
+## Usage Examples
+
+### hours
+
+```bash
+git-productivity-analyzer hours --working-dir path/to/repo
+```
+
+Totals show estimated hours and approximate work days based on commit spacing.
+
+### commit-frequency
+
+```bash
+git-productivity-analyzer commit-frequency --working-dir path/to/repo
+```
+
+Counts commits per day and week to gauge sustained engagement.
+
+### streaks
+
+```bash
+git-productivity-analyzer streaks --working-dir path/to/repo --author Alice
+```
+
+Reports the longest span of consecutive commit days for each author.
+
+### time-of-day
+
+```bash
+git-productivity-analyzer time-of-day --working-dir path/to/repo --bins 12
+```
+
+Builds a histogram of commit times to reveal typical working hours.
+
+### churn
+
+```bash
+git-productivity-analyzer churn --working-dir path/to/repo --per-file
+```
+
+Summarizes lines added and removed which can highlight refactoring activity.
+
+### commit-size
+
+```bash
+git-productivity-analyzer commit-size --working-dir path/to/repo --percentiles 50,90
+```
+
+Shows how many files and lines change per commit. Large outliers may need more review.
+
+### frecency
+
+```bash
+git-productivity-analyzer frecency --working-dir path/to/repo --path-only
+```
+
+Ranks files by a score that favors recent and frequent changes.
+
+### ownership
+
+```bash
+git-productivity-analyzer ownership --working-dir path/to/repo --depth 1
+```
+
+Displays commit percentages per directory to identify subject matter experts.
+
 ## Time Estimation Algorithm
 
 The implementation is based on `gitoxide-core::hours::estimate_hours()` which groups commits by author and time. Commits spaced less than two hours apart are considered part of the same working session. Each session starts with an initial two hour bonus to cover context switching. Optionally the diff of each commit can be examined to track files and lines changed. Identities are unified via `.mailmap` and GitHub bots can be ignored.
@@ -138,3 +204,12 @@ Configure `RUST_LOG` or the `--log-level` flag to control their visibility.
 `ownership` shows what percentage of commits each contributor made per directory. The `--depth` option controls how many path segments are used when grouping files. Using `--depth 0` groups all files together. Files in the repository root are always grouped under the `.` directory.
 Merge commits are compared against their first parent only. Changes are counted per file and aggregated by directory. Authors are sorted by descending percentage with alphabetical ordering used to break ties.
 This helps identify experts for specific modules and highlights areas with a high bus factor.
+
+## Running Tests
+
+Execute all end-to-end checks with:
+
+```bash
+cargo test-short -p git-productivity-analyzer
+```
+

--- a/git-productivity-analyzer/README.md
+++ b/git-productivity-analyzer/README.md
@@ -216,4 +216,6 @@ cargo test-short -p git-productivity-analyzer
 The `test-short` and `check-short` commands are convenience aliases defined in
 `.cargo/config.toml` to run `cargo test --message-format short` and
 `cargo check --message-format short` respectively.
+You can run `cargo check-short -p git-productivity-analyzer` for a quick build
+check without executing tests.
 

--- a/git-productivity-analyzer/tests/churn.rs
+++ b/git-productivity-analyzer/tests/churn.rs
@@ -1,0 +1,106 @@
+use assert_cmd::cargo::cargo_bin;
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn init_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    Command::new("git").arg("init").current_dir(repo).output().unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    // first commit by Alice
+    File::create(repo.join("a.txt")).unwrap();
+    Command::new("git")
+        .args(["add", "a.txt"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args([
+            "-c",
+            "user.name=Alice",
+            "-c",
+            "user.email=a@example.com",
+            "commit",
+            "-m",
+            "a1",
+        ])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    // second commit by Bob modifies a
+    let mut f = File::create(repo.join("a.txt")).unwrap();
+    writeln!(f, "more").unwrap();
+    Command::new("git")
+        .args(["add", "a.txt"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args([
+            "-c",
+            "user.name=Bob",
+            "-c",
+            "user.email=b@example.com",
+            "commit",
+            "-m",
+            "b1",
+        ])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    // third commit by Alice adds new file
+    File::create(repo.join("b.txt")).unwrap();
+    Command::new("git")
+        .args(["add", "b.txt"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args([
+            "-c",
+            "user.name=Alice",
+            "-c",
+            "user.email=a@example.com",
+            "commit",
+            "-m",
+            "a2",
+        ])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    dir
+}
+
+fn bin() -> std::path::PathBuf {
+    cargo_bin("git-productivity-analyzer")
+}
+
+#[test]
+fn churn_by_author() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args(["churn", "--working-dir", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("Alice"));
+    assert!(out.contains("Bob"));
+}
+
+#[test]
+fn churn_per_file() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args(["churn", "--working-dir", dir.path().to_str().unwrap(), "--per-file"])
+        .output()
+        .unwrap();
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("a.txt"));
+    assert!(out.contains("b.txt"));
+}

--- a/git-productivity-analyzer/tests/churn.rs
+++ b/git-productivity-analyzer/tests/churn.rs
@@ -4,15 +4,11 @@ use std::io::Write;
 use std::process::Command;
 use tempfile::TempDir;
 
+mod util;
+
 fn init_repo() -> TempDir {
-    let dir = TempDir::new().unwrap();
+    let dir = util::init_repo();
     let repo = dir.path();
-    Command::new("git").arg("init").current_dir(repo).output().unwrap();
-    Command::new("git")
-        .args(["config", "commit.gpgsign", "false"])
-        .current_dir(repo)
-        .output()
-        .unwrap();
     // first commit by Alice
     File::create(repo.join("a.txt")).unwrap();
     Command::new("git")

--- a/git-productivity-analyzer/tests/commit_frequency.rs
+++ b/git-productivity-analyzer/tests/commit_frequency.rs
@@ -1,0 +1,78 @@
+use assert_cmd::cargo::cargo_bin;
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn init_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    Command::new("git").arg("init").current_dir(repo).output().unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let authors = [
+        ("Sebastian Thiel", "a@example.com"),
+        ("Eliah Kagan", "b@example.com"),
+        ("Edward Shen", "c@example.com"),
+    ];
+    for (name, email) in authors.iter() {
+        let file = format!("{}.txt", name.replace(' ', "_"));
+        File::create(repo.join(&file)).unwrap();
+        Command::new("git")
+            .args(["add", &file])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args([
+                "-c",
+                &format!("user.name={}", name),
+                "-c",
+                &format!("user.email={}", email),
+                "commit",
+                "-m",
+                name,
+            ])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+    }
+    dir
+}
+
+fn bin() -> std::path::PathBuf {
+    cargo_bin("git-productivity-analyzer")
+}
+
+#[test]
+fn default_run() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args(["commit-frequency", "--working-dir", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("Sebastian"));
+    assert!(out.contains("Eliah"));
+}
+
+#[test]
+fn author_filter() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args([
+            "commit-frequency",
+            "--working-dir",
+            dir.path().to_str().unwrap(),
+            "--author",
+            "Sebastian",
+        ])
+        .output()
+        .unwrap();
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("Sebastian"));
+    assert!(!out.contains("Eliah"));
+}

--- a/git-productivity-analyzer/tests/commit_size.rs
+++ b/git-productivity-analyzer/tests/commit_size.rs
@@ -1,0 +1,65 @@
+use assert_cmd::cargo::cargo_bin;
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn init_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    Command::new("git").arg("init").current_dir(repo).output().unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    for i in 1..=3 {
+        let mut f = File::create(repo.join(format!("f{i}"))).unwrap();
+        for _ in 0..i {
+            writeln!(f, "{i}").unwrap();
+        }
+        Command::new("git")
+            .args(["add", &format!("f{i}")])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", &format!("c{i}")])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+    }
+    dir
+}
+
+fn bin() -> std::path::PathBuf {
+    cargo_bin("git-productivity-analyzer")
+}
+
+#[test]
+fn default_run() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args(["commit-size", "--working-dir", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&output.stdout).contains("files per commit"));
+}
+
+#[test]
+fn percentiles() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args([
+            "--json",
+            "commit-size",
+            "--working-dir",
+            dir.path().to_str().unwrap(),
+            "--percentiles",
+            "50,100",
+        ])
+        .output()
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(v.get("line_percentiles").is_some());
+}

--- a/git-productivity-analyzer/tests/frecency.rs
+++ b/git-productivity-analyzer/tests/frecency.rs
@@ -158,8 +158,10 @@ fn path_only() {
         .output()
         .unwrap();
     let text = String::from_utf8_lossy(&output.stdout);
-    // output should only contain file names without scores
-    assert!(text.lines().all(|l| !l.contains(' ')));
+    // each line should contain exactly one whitespace-separated field
+    for line in text.lines() {
+        assert_eq!(line.split_whitespace().count(), 1);
+    }
 }
 
 #[test]

--- a/git-productivity-analyzer/tests/hours.rs
+++ b/git-productivity-analyzer/tests/hours.rs
@@ -4,15 +4,11 @@ use std::io::Write;
 use std::process::Command;
 use tempfile::TempDir;
 
+mod util;
+
 fn init_repo() -> TempDir {
-    let dir = TempDir::new().unwrap();
+    let dir = util::init_repo();
     let repo = dir.path();
-    Command::new("git").arg("init").current_dir(repo).output().unwrap();
-    Command::new("git")
-        .args(["config", "commit.gpgsign", "false"])
-        .current_dir(repo)
-        .output()
-        .unwrap();
     Command::new("git")
         .args(["config", "user.name", "Sebastian Thiel"])
         .current_dir(repo)

--- a/git-productivity-analyzer/tests/ownership.rs
+++ b/git-productivity-analyzer/tests/ownership.rs
@@ -3,15 +3,11 @@ use std::fs::{self, File};
 use std::process::Command;
 use tempfile::TempDir;
 
+mod util;
+
 fn init_repo() -> TempDir {
-    let dir = TempDir::new().unwrap();
+    let dir = util::init_repo();
     let repo = dir.path();
-    Command::new("git").arg("init").current_dir(repo).output().unwrap();
-    Command::new("git")
-        .args(["config", "commit.gpgsign", "false"])
-        .current_dir(repo)
-        .output()
-        .unwrap();
     fs::create_dir(repo.join("src")).unwrap();
     fs::create_dir(repo.join("docs")).unwrap();
     File::create(repo.join("README")).unwrap();
@@ -96,5 +92,9 @@ fn ownership_json() {
         .args(["--json", "ownership", "--working-dir", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
-    serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(v.is_object());
+    for (_dir, authors) in v.as_object().unwrap() {
+        assert!(authors.is_object());
+    }
 }

--- a/git-productivity-analyzer/tests/ownership.rs
+++ b/git-productivity-analyzer/tests/ownership.rs
@@ -93,8 +93,10 @@ fn ownership_json() {
         .output()
         .unwrap();
     let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(v.is_object());
-    for (_dir, authors) in v.as_object().unwrap() {
-        assert!(authors.is_object());
-    }
+    let obj = v.as_object().expect("top-level JSON object");
+    assert!(obj.contains_key("."));
+    assert!(obj.contains_key("src"));
+    assert!(obj.contains_key("docs"));
+    let src = obj.get("src").unwrap().as_object().unwrap();
+    assert!(src.contains_key("Alice <a@example.com>"));
 }

--- a/git-productivity-analyzer/tests/ownership.rs
+++ b/git-productivity-analyzer/tests/ownership.rs
@@ -1,0 +1,100 @@
+use assert_cmd::cargo::cargo_bin;
+use std::fs::{self, File};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn init_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    Command::new("git").arg("init").current_dir(repo).output().unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    fs::create_dir(repo.join("src")).unwrap();
+    fs::create_dir(repo.join("docs")).unwrap();
+    File::create(repo.join("README")).unwrap();
+    Command::new("git")
+        .args(["add", "README"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args([
+            "-c",
+            "user.name=Alice",
+            "-c",
+            "user.email=a@example.com",
+            "commit",
+            "-m",
+            "root",
+        ])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    File::create(repo.join("src/a")).unwrap();
+    Command::new("git")
+        .args(["add", "src/a"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args([
+            "-c",
+            "user.name=Alice",
+            "-c",
+            "user.email=a@example.com",
+            "commit",
+            "-m",
+            "init",
+        ])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    File::create(repo.join("docs/b")).unwrap();
+    Command::new("git")
+        .args(["add", "docs/b"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args([
+            "-c",
+            "user.name=Bob",
+            "-c",
+            "user.email=b@example.com",
+            "commit",
+            "-m",
+            "docs",
+        ])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    dir
+}
+
+fn bin() -> std::path::PathBuf {
+    cargo_bin("git-productivity-analyzer")
+}
+
+#[test]
+fn ownership_default() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args(["ownership", "--working-dir", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(!output.stdout.is_empty());
+}
+
+#[test]
+fn ownership_json() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args(["--json", "ownership", "--working-dir", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+}

--- a/git-productivity-analyzer/tests/streaks.rs
+++ b/git-productivity-analyzer/tests/streaks.rs
@@ -4,15 +4,11 @@ use std::io::Write;
 use std::process::Command;
 use tempfile::TempDir;
 
+mod util;
+
 fn init_repo() -> TempDir {
-    let dir = TempDir::new().unwrap();
+    let dir = util::init_repo();
     let repo = dir.path();
-    Command::new("git").arg("init").current_dir(repo).output().unwrap();
-    Command::new("git")
-        .args(["config", "commit.gpgsign", "false"])
-        .current_dir(repo)
-        .output()
-        .unwrap();
     let commits = [
         ("Alice", "a@example.com", "2020-01-01T00:00:00 +0000"),
         ("Alice", "a@example.com", "2020-01-02T00:00:00 +0000"),

--- a/git-productivity-analyzer/tests/streaks.rs
+++ b/git-productivity-analyzer/tests/streaks.rs
@@ -1,0 +1,85 @@
+use assert_cmd::cargo::cargo_bin;
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn init_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    Command::new("git").arg("init").current_dir(repo).output().unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let commits = [
+        ("Alice", "a@example.com", "2020-01-01T00:00:00 +0000"),
+        ("Alice", "a@example.com", "2020-01-02T00:00:00 +0000"),
+        ("Alice", "a@example.com", "2020-01-03T00:00:00 +0000"),
+        ("Bob", "b@example.com", "2020-01-01T00:00:00 +0000"),
+        ("Bob", "b@example.com", "2020-01-04T00:00:00 +0000"),
+        ("Alice", "a@example.com", "2020-01-05T00:00:00 +0000"),
+    ];
+    for (i, (name, email, date)) in commits.iter().enumerate() {
+        let mut f = File::create(repo.join(format!("f{i}"))).unwrap();
+        writeln!(f, "{i}").unwrap();
+        Command::new("git")
+            .args(["add", &format!("f{i}")])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args([
+                "-c",
+                &format!("user.name={}", name),
+                "-c",
+                &format!("user.email={}", email),
+                "commit",
+                "-m",
+                &format!("c{i}"),
+                "--date",
+                date,
+            ])
+            .env("GIT_AUTHOR_DATE", date)
+            .env("GIT_COMMITTER_DATE", date)
+            .current_dir(repo)
+            .output()
+            .unwrap();
+    }
+    dir
+}
+
+fn bin() -> std::path::PathBuf {
+    cargo_bin("git-productivity-analyzer")
+}
+
+#[test]
+fn streaks_default() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args(["streaks", "--working-dir", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("Alice"));
+    assert!(out.contains("Bob"));
+}
+
+#[test]
+fn streaks_filtered() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args([
+            "streaks",
+            "--working-dir",
+            dir.path().to_str().unwrap(),
+            "--author",
+            "Alice",
+        ])
+        .output()
+        .unwrap();
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("Alice"));
+    assert!(!out.contains("Bob"));
+}

--- a/git-productivity-analyzer/tests/time_of_day.rs
+++ b/git-productivity-analyzer/tests/time_of_day.rs
@@ -67,7 +67,7 @@ fn author_filter() {
             "--working-dir",
             dir.path().to_str().unwrap(),
             "--author",
-            "A",
+            "a@example.com",
         ])
         .output()
         .unwrap();
@@ -75,4 +75,10 @@ fn author_filter() {
     let lines: Vec<_> = out.lines().collect();
     assert_eq!(lines.len(), 24);
     assert!(lines.iter().any(|l| l.starts_with("00-00") && l.ends_with("1")));
+    let total: u32 = lines
+        .iter()
+        .filter_map(|l| l.split_whitespace().nth(1))
+        .filter_map(|v| v.parse::<u32>().ok())
+        .sum();
+    assert_eq!(total, 1);
 }

--- a/git-productivity-analyzer/tests/time_of_day.rs
+++ b/git-productivity-analyzer/tests/time_of_day.rs
@@ -1,0 +1,80 @@
+use assert_cmd::cargo::cargo_bin;
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn init_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    Command::new("git").arg("init").current_dir(repo).output().unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let commits = [
+        ("A", "2020-01-01T00:00:00 +0000"),
+        ("B", "2020-01-01T12:00:00 +0000"),
+        ("C", "2020-01-01T23:00:00 +0000"),
+    ];
+    for (i, (name, date)) in commits.iter().enumerate() {
+        let mut f = File::create(repo.join(format!("f{i}"))).unwrap();
+        writeln!(f, "{i}").unwrap();
+        Command::new("git")
+            .args(["add", &format!("f{i}")])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args([
+                "-c",
+                &format!("user.name={}", name),
+                "-c",
+                &format!("user.email={}@example.com", name.to_lowercase()),
+                "commit",
+                "-m",
+                name,
+                "--date",
+                date,
+            ])
+            .env("GIT_AUTHOR_DATE", date)
+            .env("GIT_COMMITTER_DATE", date)
+            .current_dir(repo)
+            .output()
+            .unwrap();
+    }
+    dir
+}
+
+fn bin() -> std::path::PathBuf {
+    cargo_bin("git-productivity-analyzer")
+}
+
+#[test]
+fn default_run() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args(["time-of-day", "--working-dir", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(!output.stdout.is_empty());
+}
+
+#[test]
+fn author_filter() {
+    let dir = init_repo();
+    let output = Command::new(bin())
+        .args([
+            "time-of-day",
+            "--working-dir",
+            dir.path().to_str().unwrap(),
+            "--author",
+            "A",
+        ])
+        .output()
+        .unwrap();
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(!out.is_empty());
+}

--- a/git-productivity-analyzer/tests/time_of_day.rs
+++ b/git-productivity-analyzer/tests/time_of_day.rs
@@ -4,15 +4,11 @@ use std::io::Write;
 use std::process::Command;
 use tempfile::TempDir;
 
+mod util;
+
 fn init_repo() -> TempDir {
-    let dir = TempDir::new().unwrap();
+    let dir = util::init_repo();
     let repo = dir.path();
-    Command::new("git").arg("init").current_dir(repo).output().unwrap();
-    Command::new("git")
-        .args(["config", "commit.gpgsign", "false"])
-        .current_dir(repo)
-        .output()
-        .unwrap();
     let commits = [
         ("A", "2020-01-01T00:00:00 +0000"),
         ("B", "2020-01-01T12:00:00 +0000"),
@@ -76,5 +72,7 @@ fn author_filter() {
         .output()
         .unwrap();
     let out = String::from_utf8_lossy(&output.stdout);
-    assert!(!out.is_empty());
+    let lines: Vec<_> = out.lines().collect();
+    assert_eq!(lines.len(), 24);
+    assert!(lines.iter().any(|l| l.starts_with("00-00") && l.ends_with("1")));
 }

--- a/git-productivity-analyzer/tests/util.rs
+++ b/git-productivity-analyzer/tests/util.rs
@@ -1,0 +1,94 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+pub fn init_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    Command::new("git").arg("init").current_dir(repo).output().unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    dir
+}
+
+pub fn init_repo_with_merge() -> TempDir {
+    let dir = init_repo();
+    let repo = dir.path();
+    Command::new("git")
+        .args(["config", "user.name", "Tester"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "tester@example.com"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+
+    let date1 = "2020-01-01T00:00:00 +0000";
+    std::fs::write(repo.join("file0.txt"), "0").unwrap();
+    Command::new("git")
+        .args(["add", "file0.txt"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "c0", "--date", date1])
+        .env("GIT_AUTHOR_DATE", date1)
+        .env("GIT_COMMITTER_DATE", date1)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["checkout", "-b", "feature"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let date_feature = "2020-01-03T00:00:00 +0000";
+    std::fs::write(repo.join("file2.txt"), "2").unwrap();
+    Command::new("git")
+        .args(["add", "file2.txt"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "feature", "--date", date_feature])
+        .env("GIT_AUTHOR_DATE", date_feature)
+        .env("GIT_COMMITTER_DATE", date_feature)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["checkout", "-"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let date_main = "2020-01-02T00:00:00 +0000";
+    std::fs::write(repo.join("file1.txt"), "1").unwrap();
+    Command::new("git")
+        .args(["add", "file1.txt"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "main", "--date", date_main])
+        .env("GIT_AUTHOR_DATE", date_main)
+        .env("GIT_COMMITTER_DATE", date_main)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["merge", "feature", "--no-ff", "-m", "merge"])
+        .env("GIT_AUTHOR_DATE", "2020-01-04T00:00:00 +0000")
+        .env("GIT_COMMITTER_DATE", "2020-01-04T00:00:00 +0000")
+        .current_dir(repo)
+        .output()
+        .unwrap();
+
+    dir
+}


### PR DESCRIPTION
## Summary
- document analyzer subcommand usage and testing instructions
- add end-to-end tests for all analyzer subcommands

## Testing
- `cargo check-short -p git-productivity-analyzer`
- `cargo test-short -p git-productivity-analyzer`

------
https://chatgpt.com/codex/tasks/task_e_68650a42e8988320a60cd95695dfcd2f

## Summary by Sourcery

Add usage examples and testing instructions to README, refactor test setup with a shared util module, and include end-to-end tests for all analyzer subcommands.

Enhancements:
- Refactor test initialization logic into a shared util module to reduce duplication.

Documentation:
- Add usage examples for each analyzer subcommand and instructions for running end-to-end tests in README.md.

Tests:
- Introduce end-to-end tests for frecency, hours, churn, ownership, commit-frequency, time-of-day, streaks, and commit-size subcommands.