### PR TITLE
Remove redundant to_lowercase call

### DIFF
--- a/git-productivity-analyzer/src/cmd/churn/args.rs
+++ b/git-productivity-analyzer/src/cmd/churn/args.rs
@@ -13,4 +13,4 @@ pub struct Args {
     pub author: Option<String>,
 }
 
-crate::impl_from_args!(Args, crate::sdk::churn::Options { per_file, author });
+crate::impl_from_args!(Args, crate::sdk::churn::Options { per_file }, { author => author | lowercase });

--- a/git-productivity-analyzer/src/cmd/churn/args.rs
+++ b/git-productivity-analyzer/src/cmd/churn/args.rs
@@ -13,4 +13,4 @@ pub struct Args {
     pub author: Option<String>,
 }
 
-crate::impl_from_args!(Args, crate::sdk::churn::Options { per_file }, { author => author | lowercase });
+crate::impl_from_args!(Args, crate::sdk::churn::Options { per_file, author | lowercase });

--- a/git-productivity-analyzer/src/cmd/commit_frequency/args.rs
+++ b/git-productivity-analyzer/src/cmd/commit_frequency/args.rs
@@ -10,4 +10,4 @@ pub struct Args {
     pub author: Option<String>,
 }
 
-crate::impl_from_args!(Args, crate::sdk::commit_frequency::Options { author });
+crate::impl_from_args!(Args, crate::sdk::commit_frequency::Options { }, { author => author | lowercase });

--- a/git-productivity-analyzer/src/cmd/commit_frequency/args.rs
+++ b/git-productivity-analyzer/src/cmd/commit_frequency/args.rs
@@ -10,4 +10,4 @@ pub struct Args {
     pub author: Option<String>,
 }
 
-crate::impl_from_args!(Args, crate::sdk::commit_frequency::Options { }, { author => author | lowercase });
+crate::impl_from_args!(Args, crate::sdk::commit_frequency::Options { author | lowercase });

--- a/git-productivity-analyzer/src/cmd/ownership/args.rs
+++ b/git-productivity-analyzer/src/cmd/ownership/args.rs
@@ -20,4 +20,4 @@ pub struct Args {
     pub depth: usize,
 }
 
-crate::impl_from_args!(Args, crate::sdk::ownership::Options { path, depth }, { author => author | lowercase });
+crate::impl_from_args!(Args, crate::sdk::ownership::Options { path, depth, author | lowercase });

--- a/git-productivity-analyzer/src/cmd/ownership/args.rs
+++ b/git-productivity-analyzer/src/cmd/ownership/args.rs
@@ -20,4 +20,4 @@ pub struct Args {
     pub depth: usize,
 }
 
-crate::impl_from_args!(Args, crate::sdk::ownership::Options { path, author, depth });
+crate::impl_from_args!(Args, crate::sdk::ownership::Options { path, depth }, { author => author | lowercase });

--- a/git-productivity-analyzer/src/cmd/streaks/args.rs
+++ b/git-productivity-analyzer/src/cmd/streaks/args.rs
@@ -13,4 +13,4 @@ pub struct Args {
     pub author: Option<String>,
 }
 
-crate::impl_from_args!(Args, crate::sdk::streaks::Options { author });
+crate::impl_from_args!(Args, crate::sdk::streaks::Options { }, { author => author | lowercase });

--- a/git-productivity-analyzer/src/cmd/streaks/args.rs
+++ b/git-productivity-analyzer/src/cmd/streaks/args.rs
@@ -13,4 +13,4 @@ pub struct Args {
     pub author: Option<String>,
 }
 
-crate::impl_from_args!(Args, crate::sdk::streaks::Options { }, { author => author | lowercase });
+crate::impl_from_args!(Args, crate::sdk::streaks::Options { author | lowercase });

--- a/git-productivity-analyzer/src/cmd/time_of_day/args.rs
+++ b/git-productivity-analyzer/src/cmd/time_of_day/args.rs
@@ -13,4 +13,4 @@ pub struct Args {
     pub author: Option<String>,
 }
 
-crate::impl_from_args!(Args, crate::sdk::time_of_day::Options { bins, author });
+crate::impl_from_args!(Args, crate::sdk::time_of_day::Options { bins }, { author => author | lowercase });

--- a/git-productivity-analyzer/src/cmd/time_of_day/args.rs
+++ b/git-productivity-analyzer/src/cmd/time_of_day/args.rs
@@ -13,4 +13,4 @@ pub struct Args {
     pub author: Option<String>,
 }
 
-crate::impl_from_args!(Args, crate::sdk::time_of_day::Options { bins }, { author => author | lowercase });
+crate::impl_from_args!(Args, crate::sdk::time_of_day::Options { bins, author | lowercase });

--- a/git-productivity-analyzer/src/sdk/churn/analyzer.rs
+++ b/git-productivity-analyzer/src/sdk/churn/analyzer.rs
@@ -71,7 +71,7 @@ impl Analyzer {
             .into_diagnostic()?;
         crate::sdk::walk_commits(&repo, start, since.as_ref(), false, |id, commit| {
             let author = commit.author().into_diagnostic()?;
-            if !crate::sdk::author_matches(&author, &self.opts.author) {
+            if !crate::sdk::author_matches_optimized(&author, &self.opts.author) {
                 return Ok(());
             }
             let author_string = format!("{} <{}>", author.name, author.email);

--- a/git-productivity-analyzer/src/sdk/commit_frequency/processor.rs
+++ b/git-productivity-analyzer/src/sdk/commit_frequency/processor.rs
@@ -13,7 +13,7 @@ pub(crate) fn process_commit(
 ) -> Result<()> {
     let author = commit.author().into_diagnostic()?;
     let author_string = format!("{} <{}>", author.name, author.email);
-    if !crate::sdk::author_matches(&author, author_filter) {
+    if !crate::sdk::author_matches_optimized(&author, author_filter) {
         return Ok(());
     }
     let ts = author.seconds();

--- a/git-productivity-analyzer/src/sdk/helpers.rs
+++ b/git-productivity-analyzer/src/sdk/helpers.rs
@@ -70,3 +70,17 @@ pub fn author_matches(author: &gix::actor::SignatureRef<'_>, filter: &Option<Str
         None => true,
     }
 }
+
+/// Optimized version of author_matches that accepts pre-lowercased patterns.
+/// This avoids the redundant to_lowercase() call when the pattern is already lowercased.
+pub fn author_matches_optimized(author: &gix::actor::SignatureRef<'_>, filter: &Option<String>) -> bool {
+    match filter {
+        Some(pattern) => {
+            // Pattern is assumed to be already lowercased
+            let name = author.name.to_str_lossy().to_lowercase();
+            let email = author.email.to_str_lossy().to_lowercase();
+            name.contains(pattern) || email.contains(pattern)
+        }
+        None => true,
+    }
+}

--- a/git-productivity-analyzer/src/sdk/mod.rs
+++ b/git-productivity-analyzer/src/sdk/mod.rs
@@ -16,6 +16,6 @@ pub use helpers::{print_json_or, run_with_analyzer, AnalyzerTrait, IntoAnalyzer}
 
 pub use common::RepoOptions;
 
-pub use helpers::author_matches;
+pub use helpers::author_matches_optimized;
 #[allow(unused_imports)]
 pub use revision::{open_with_range, resolve_since_commit, resolve_start_commit, walk_commits};

--- a/git-productivity-analyzer/src/sdk/ownership/analyzer.rs
+++ b/git-productivity-analyzer/src/sdk/ownership/analyzer.rs
@@ -33,7 +33,7 @@ impl Analyzer {
         let mut totals = BTreeMap::<String, BTreeMap<String, u32>>::new();
         crate::sdk::walk_commits(&repo, start, since.as_ref(), false, |id, commit| {
             let author = commit.author().into_diagnostic()?;
-            if !crate::sdk::author_matches(&author, &self.opts.author) {
+            if !crate::sdk::author_matches_optimized(&author, &self.opts.author) {
                 return Ok(());
             }
             let author_string = format!("{} <{}>", author.name, author.email);

--- a/git-productivity-analyzer/src/sdk/streaks/processor.rs
+++ b/git-productivity-analyzer/src/sdk/streaks/processor.rs
@@ -10,7 +10,7 @@ pub(crate) fn process_commit(
     by_author: &mut BTreeMap<String, BTreeSet<NaiveDate>>,
 ) -> Result<()> {
     let author = commit.author().into_diagnostic()?;
-    if !crate::sdk::author_matches(&author, author_filter) {
+    if !crate::sdk::author_matches_optimized(&author, author_filter) {
         return Ok(());
     }
     let ts = author.seconds();

--- a/git-productivity-analyzer/src/sdk/time_of_day/processor.rs
+++ b/git-productivity-analyzer/src/sdk/time_of_day/processor.rs
@@ -5,7 +5,7 @@ use crate::error::Result;
 
 pub(crate) fn process_commit(commit: gix::Commit<'_>, author_filter: &Option<String>, bins: &mut [u32]) -> Result<()> {
     let author = commit.author().into_diagnostic()?;
-    if !crate::sdk::author_matches(&author, author_filter) {
+    if !crate::sdk::author_matches_optimized(&author, author_filter) {
         return Ok(());
     }
     let time = author.time().into_diagnostic()?;

--- a/git-productivity-analyzer/tests/commit_size.rs
+++ b/git-productivity-analyzer/tests/commit_size.rs
@@ -68,3 +68,25 @@ fn percentiles() {
     let expected = serde_json::json!([[50.0, 2], [100.0, 3]]);
     assert_eq!(v.get("line_percentiles").unwrap(), &expected);
 }
+
+#[test]
+fn empty_repository() {
+    let dir = util::init_repo();
+    let output = Command::new(bin())
+        .args(["commit-size", "--working-dir", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    
+    // Assert the process exits with a specific code (0 for success, non-zero for expected failure)
+    assert!(output.status.success() || output.status.code() == Some(1));
+    
+    // Assert stderr does not contain unexpected errors or panics
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("panic"));
+    assert!(!stderr.contains("fatal"));
+    assert!(!stderr.contains("internal error"));
+    
+    // The command may fail on an empty repository but should not panic
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.trim().is_empty() || stdout.contains("No commits") || stdout.contains("0"));
+}

--- a/git-productivity-analyzer/tests/frecency.rs
+++ b/git-productivity-analyzer/tests/frecency.rs
@@ -181,38 +181,34 @@ fn json_output() {
         .unwrap();
     let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     
-    // Assert specific structure and values instead of just parsing
-    let arr = v.as_array().expect("JSON should be an array");
-    assert_eq!(arr.len(), 3, "Should have exactly 3 files");
+    use util::json_test_helpers::*;
     
-    // Each entry should have proper frecency structure
+    // Validate that it's an array with the expected structure
+    let required_fields = &["path", "score"];
+    let arr = validate_object_array(&v, required_fields, "Frecency results");
+    assert_array_length(arr, 3, "Frecency results");
+    
+    // Check each entry's specific values
     for entry in arr {
-        let obj = entry.as_object().expect("Each entry should be an object");
+        let obj = assert_json_object(entry, "Frecency entry");
         
-        // Assert required fields exist with correct types
-        assert!(obj.contains_key("path"), "Entry should have a path");
-        assert!(obj.contains_key("score"), "Entry should have a score");
-        
-        let path = obj.get("path").unwrap().as_str().unwrap();
-        let score = obj.get("score").unwrap().as_f64().unwrap();
+        let path = assert_string(assert_contains_key(obj, "path", "Frecency entry"), "path");
+        let score = assert_number(assert_contains_key(obj, "score", "Frecency entry"), "score");
         
         // Path should be one of our test files
         assert!(path.starts_with("file") && path.ends_with(".txt"), 
                "Path should match expected pattern: {}", path);
         
         // Score should be positive
-        assert!(score > 0.0, "Score should be positive: {}", score);
+        assert_positive(score, "Frecency score");
     }
     
     // Assert that the results are sorted by score in descending order (default)
     let scores: Vec<f64> = arr.iter()
-        .map(|entry| entry.as_object().unwrap().get("score").unwrap().as_f64().unwrap())
+        .map(|entry| assert_number(assert_contains_key(assert_json_object(entry, "score entry"), "score", "score entry"), "score"))
         .collect();
     
-    for i in 1..scores.len() {
-        assert!(scores[i-1] >= scores[i], 
-               "Scores should be in descending order: {} >= {}", scores[i-1], scores[i]);
-    }
+    assert_descending_order(&scores, "Frecency scores");
 }
 
 #[test]

--- a/git-productivity-analyzer/tests/hours.rs
+++ b/git-productivity-analyzer/tests/hours.rs
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERRORuse assert_cmd::cargo::cargo_bin;
+use assert_cmd::cargo::cargo_bin;
 use std::fs::File;
 use std::io::Write;
 use std::process::Command;
@@ -101,26 +101,23 @@ fn json_output() {
         .unwrap();
     let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     
-    // Assert specific structure and values instead of just parsing
-    let obj = v.as_object().expect("top-level JSON object");
+    use util::json_test_helpers::*;
     
-    // Assert essential fields exist with correct types
-    assert!(obj.contains_key("total_commits"));
-    assert!(obj.contains_key("total_hours"));
-    assert!(obj.contains_key("total_8h_days"));
-    assert!(obj.contains_key("total_authors"));
+    // Validate the JSON structure has expected fields
+    let expected_fields = &["total_commits", "total_hours", "total_8h_days", "total_authors"];
+    let obj = validate_analytics_json(&v, expected_fields);
     
     // Assert the values make sense for our test data (3 commits)
-    let total_commits = obj.get("total_commits").unwrap().as_u64().unwrap();
+    let total_commits = assert_u64(assert_contains_key(obj, "total_commits", "hours output"), "total_commits");
     assert_eq!(total_commits, 3, "Should have exactly 3 commits");
     
-    let total_hours = obj.get("total_hours").unwrap().as_f64().unwrap();
-    assert!(total_hours > 0.0, "Total hours should be positive");
+    let total_hours = assert_number(assert_contains_key(obj, "total_hours", "hours output"), "total_hours");
+    assert_positive(total_hours, "Total hours");
     
-    let total_8h_days = obj.get("total_8h_days").unwrap().as_f64().unwrap();
-    assert!(total_8h_days > 0.0, "Total 8h days should be positive");
+    let total_8h_days = assert_number(assert_contains_key(obj, "total_8h_days", "hours output"), "total_8h_days");
+    assert_positive(total_8h_days, "Total 8h days");
     
-    let total_authors = obj.get("total_authors").unwrap().as_u64().unwrap();
+    let total_authors = assert_u64(assert_contains_key(obj, "total_authors", "hours output"), "total_authors");
     assert_eq!(total_authors, 1, "Should have exactly 1 author (Sebastian Thiel)");
 }
 

--- a/git-productivity-analyzer/tests/hours.rs
+++ b/git-productivity-analyzer/tests/hours.rs
@@ -99,7 +99,29 @@ fn json_output() {
         .args(["--json", "hours", "--working-dir", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
-    serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    
+    // Assert specific structure and values instead of just parsing
+    let obj = v.as_object().expect("top-level JSON object");
+    
+    // Assert essential fields exist with correct types
+    assert!(obj.contains_key("total_commits"));
+    assert!(obj.contains_key("total_hours"));
+    assert!(obj.contains_key("total_8h_days"));
+    assert!(obj.contains_key("total_authors"));
+    
+    // Assert the values make sense for our test data (3 commits)
+    let total_commits = obj.get("total_commits").unwrap().as_u64().unwrap();
+    assert_eq!(total_commits, 3, "Should have exactly 3 commits");
+    
+    let total_hours = obj.get("total_hours").unwrap().as_f64().unwrap();
+    assert!(total_hours > 0.0, "Total hours should be positive");
+    
+    let total_8h_days = obj.get("total_8h_days").unwrap().as_f64().unwrap();
+    assert!(total_8h_days > 0.0, "Total 8h days should be positive");
+    
+    let total_authors = obj.get("total_authors").unwrap().as_u64().unwrap();
+    assert_eq!(total_authors, 1, "Should have exactly 1 author (Sebastian Thiel)");
 }
 
 #[test]

--- a/git-productivity-analyzer/tests/hours.rs
+++ b/git-productivity-analyzer/tests/hours.rs
@@ -1,4 +1,4 @@
-use assert_cmd::cargo::cargo_bin;
+THIS SHOULD BE A LINTER ERRORuse assert_cmd::cargo::cargo_bin;
 use std::fs::File;
 use std::io::Write;
 use std::process::Command;

--- a/git-productivity-analyzer/tests/ownership.rs
+++ b/git-productivity-analyzer/tests/ownership.rs
@@ -94,9 +94,25 @@ fn ownership_json() {
         .unwrap();
     let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let obj = v.as_object().expect("top-level JSON object");
+    
+    // Assert specific structure and values instead of just key existence
     assert!(obj.contains_key("."));
     assert!(obj.contains_key("src"));
     assert!(obj.contains_key("docs"));
+    
+    // Assert that the root directory has the expected structure
+    let root = obj.get(".").unwrap().as_object().unwrap();
+    assert!(root.contains_key("Alice <a@example.com>"));
+    
+    // Assert the src directory has Alice's ownership
     let src = obj.get("src").unwrap().as_object().unwrap();
     assert!(src.contains_key("Alice <a@example.com>"));
+    let alice_src = src.get("Alice <a@example.com>").unwrap().as_f64().unwrap();
+    assert!(alice_src > 0.0, "Alice should have ownership percentage in src");
+    
+    // Assert the docs directory has Bob's ownership
+    let docs = obj.get("docs").unwrap().as_object().unwrap();
+    assert!(docs.contains_key("Bob <b@example.com>"));
+    let bob_docs = docs.get("Bob <b@example.com>").unwrap().as_f64().unwrap();
+    assert!(bob_docs > 0.0, "Bob should have ownership percentage in docs");
 }

--- a/git-productivity-analyzer/tests/util.rs
+++ b/git-productivity-analyzer/tests/util.rs
@@ -75,12 +75,12 @@ pub mod json_test_helpers {
     use serde_json::Value;
     
     /// Assert that a JSON value is an object and return it
-    pub fn assert_json_object(value: &Value, context: &str) -> &serde_json::Map<String, Value> {
+    pub fn assert_json_object<'a>(value: &'a Value, context: &'a str) -> &'a serde_json::Map<String, Value> {
         value.as_object().unwrap_or_else(|| panic!("{} should be a JSON object", context))
     }
     
     /// Assert that a JSON value is an array and return it
-    pub fn assert_json_array(value: &Value, context: &str) -> &Vec<Value> {
+    pub fn assert_json_array<'a>(value: &'a Value, context: &'a str) -> &'a Vec<Value> {
         value.as_array().unwrap_or_else(|| panic!("{} should be a JSON array", context))
     }
     
@@ -100,7 +100,7 @@ pub mod json_test_helpers {
     }
     
     /// Assert that a JSON value is a string and return it
-    pub fn assert_string(value: &Value, context: &str) -> &str {
+    pub fn assert_string<'a>(value: &'a Value, context: &'a str) -> &'a str {
         value.as_str().unwrap_or_else(|| panic!("{} should be a string", context))
     }
     
@@ -124,7 +124,7 @@ pub mod json_test_helpers {
     }
     
     /// Validate common JSON structure for analytics output
-    pub fn validate_analytics_json(json: &Value, expected_fields: &[&str]) -> &serde_json::Map<String, Value> {
+    pub fn validate_analytics_json<'a>(json: &'a Value, expected_fields: &'a [&'a str]) -> &'a serde_json::Map<String, Value> {
         let obj = assert_json_object(json, "Analytics output");
         
         // Check that all expected fields are present
@@ -136,14 +136,15 @@ pub mod json_test_helpers {
     }
     
     /// Validate an array of objects where each object has required fields
-    pub fn validate_object_array(json: &Value, required_fields: &[&str], context: &str) -> &Vec<Value> {
+    pub fn validate_object_array<'a>(json: &'a Value, required_fields: &'a [&'a str], context: &'a str) -> &'a Vec<Value> {
         let arr = assert_json_array(json, context);
         
         for (i, entry) in arr.iter().enumerate() {
-            let obj = assert_json_object(entry, &format!("{} entry {}", context, i));
+            let entry_context = format!("{} entry {}", context, i);
+            let obj = assert_json_object(entry, &entry_context);
             
             for field in required_fields {
-                assert_contains_key(obj, field, &format!("{} entry {}", context, i));
+                assert_contains_key(obj, field, &entry_context);
             }
         }
         

--- a/git-productivity-analyzer/tests/util.rs
+++ b/git-productivity-analyzer/tests/util.rs
@@ -69,3 +69,84 @@ pub fn run(args: &[&str]) -> std::process::Output {
         .output()
         .unwrap()
 }
+
+/// Helper functions for JSON test validation to reduce boilerplate
+pub mod json_test_helpers {
+    use serde_json::Value;
+    
+    /// Assert that a JSON value is an object and return it
+    pub fn assert_json_object(value: &Value, context: &str) -> &serde_json::Map<String, Value> {
+        value.as_object().unwrap_or_else(|| panic!("{} should be a JSON object", context))
+    }
+    
+    /// Assert that a JSON value is an array and return it
+    pub fn assert_json_array(value: &Value, context: &str) -> &Vec<Value> {
+        value.as_array().unwrap_or_else(|| panic!("{} should be a JSON array", context))
+    }
+    
+    /// Assert that a JSON object contains a key and return the value
+    pub fn assert_contains_key<'a>(obj: &'a serde_json::Map<String, Value>, key: &str, context: &str) -> &'a Value {
+        obj.get(key).unwrap_or_else(|| panic!("{} should contain key '{}'", context, key))
+    }
+    
+    /// Assert that a JSON value is a number and return it as f64
+    pub fn assert_number(value: &Value, context: &str) -> f64 {
+        value.as_f64().unwrap_or_else(|| panic!("{} should be a number", context))
+    }
+    
+    /// Assert that a JSON value is a u64 and return it
+    pub fn assert_u64(value: &Value, context: &str) -> u64 {
+        value.as_u64().unwrap_or_else(|| panic!("{} should be a u64", context))
+    }
+    
+    /// Assert that a JSON value is a string and return it
+    pub fn assert_string(value: &Value, context: &str) -> &str {
+        value.as_str().unwrap_or_else(|| panic!("{} should be a string", context))
+    }
+    
+    /// Assert that a number is positive
+    pub fn assert_positive(value: f64, context: &str) {
+        assert!(value > 0.0, "{} should be positive, got {}", context, value);
+    }
+    
+    /// Assert that an array has the expected length
+    pub fn assert_array_length(arr: &[Value], expected_len: usize, context: &str) {
+        assert_eq!(arr.len(), expected_len, "{} should have {} elements, got {}", context, expected_len, arr.len());
+    }
+    
+    /// Assert that values in an array are in descending order
+    pub fn assert_descending_order(values: &[f64], context: &str) {
+        for i in 1..values.len() {
+            assert!(values[i-1] >= values[i], 
+                   "{} should be in descending order: {} >= {} at positions {} and {}", 
+                   context, values[i-1], values[i], i-1, i);
+        }
+    }
+    
+    /// Validate common JSON structure for analytics output
+    pub fn validate_analytics_json(json: &Value, expected_fields: &[&str]) -> &serde_json::Map<String, Value> {
+        let obj = assert_json_object(json, "Analytics output");
+        
+        // Check that all expected fields are present
+        for field in expected_fields {
+            assert_contains_key(obj, field, "Analytics output");
+        }
+        
+        obj
+    }
+    
+    /// Validate an array of objects where each object has required fields
+    pub fn validate_object_array(json: &Value, required_fields: &[&str], context: &str) -> &Vec<Value> {
+        let arr = assert_json_array(json, context);
+        
+        for (i, entry) in arr.iter().enumerate() {
+            let obj = assert_json_object(entry, &format!("{} entry {}", context, i));
+            
+            for field in required_fields {
+                assert_contains_key(obj, field, &format!("{} entry {}", context, i));
+            }
+        }
+        
+        arr
+    }
+}

--- a/git-productivity-analyzer/tests/util.rs
+++ b/git-productivity-analyzer/tests/util.rs
@@ -61,3 +61,11 @@ pub fn init_repo_with_merge() -> TempDir {
     );
     dir
 }
+
+pub fn run(args: &[&str]) -> std::process::Output {
+    use assert_cmd::cargo::cargo_bin;
+    Command::new(cargo_bin("git-productivity-analyzer"))
+        .args(args)
+        .output()
+        .unwrap()
+}


### PR DESCRIPTION
Optimize author matching by removing redundant lowercase calls and refactor argument parsing.

The `author_matches` function was redundantly calling `to_lowercase()` on patterns already pre-lowercased by the `impl_from_args!` macro, defeating an intended optimization. This PR introduces an optimized function and updates the macro to ensure patterns are lowercased only once. Additionally, the `impl_from_args!` macro was refactored for more flexible field transformations, JSON tests were enhanced with specific assertions, and the empty repository test was improved for robustness.

## Summary by Sourcery

Optimize author filtering by removing redundant lowercase calls and introducing a new optimized matcher, enhance the argument parsing macro with transformation support (e.g., lowercase), update command mappings to lowercase author filters at parse time, and strengthen JSON tests with detailed assertions and an empty-repo scenario.

New Features:
- Introduce author_matches_optimized to accept pre-lowercased patterns
- Extend impl_from_args macro to support field transformations like lowercase

Enhancements:
- Replace all author_matches calls with the optimized variant to eliminate redundant lowercasing
- Update impl_from_args mappings for command options to apply lowercase at parse time

Tests:
- Enhance JSON output tests in frecency, hours, ownership, and commit_size with detailed structure, value, and sorting assertions
- Add an empty repository test in commit_size to verify graceful handling without panics

Chores:
- Add run helper in test util for invoking the binary
- Re-export author_matches_optimized in SDK instead of the old function